### PR TITLE
plugins/ruby: fix incomplete env setup

### DIFF
--- a/plugins/ruby/NWNXRuby.cpp
+++ b/plugins/ruby/NWNXRuby.cpp
@@ -55,7 +55,11 @@ bool CNWNXRuby::OnCreate(gline *config, const char *LogDir)
 	Log(0,"NWNX Ruby V.1.1.0\n");
 	Log(0,"(c) by virusman, 2008-2013\n");
 
+	RUBY_INIT_STACK;
 	ruby_init();
+	static char* args[] = { "ruby", "/dev/null" };
+	ruby_process_options(2, args);
+
 	
 	struct sigaction sa;
 	memset(&sa, 0, sizeof(struct sigaction));


### PR DESCRIPTION
Ruby 1.9.x has a small bug that doesn't set up the whole env properly when doing it like we do. This means that some things related to threads/mutexes aren't available.

See: http://www.ruby-forum.com/topic/4408161
