### PR TITLE
plugins/chat: allow sending chat messages to individual players

### DIFF
--- a/plugins/chat/HookChat.h
+++ b/plugins/chat/HookChat.h
@@ -34,6 +34,7 @@ void RunScript(char * sname, int ObjID);
 unsigned long * GetPCobj(dword OID);
 unsigned long GetID(dword OID);
 int SendMsg(const int mode, const int id, char *msg, const int to);
+int SendMsgSingle(const int mode, const int conn, const int speaker, char *msg);
 
 extern char scriptRun;
 extern char *lastMsg;

--- a/plugins/chat/NWNXChat.h
+++ b/plugins/chat/NWNXChat.h
@@ -47,6 +47,7 @@ public:
   int CCMessage(const int objID, const int type, const int subtype, CNWCCMessageData* messageData);
 protected:
   char *SendMessage(char* Parameters);
+  char *SendMessageSingle(char* Parameters);
 };
 
 #endif

--- a/plugins/chat/nwn/nwnx_chat.nss
+++ b/plugins/chat/nwn/nwnx_chat.nss
@@ -8,6 +8,10 @@ const int CHAT_CHANNEL_PRIVATE     = 4;
 const int CHAT_CHANNEL_SERVER_MSG  = 5;
 const int CHAT_CHANNEL_PARTY       = 6;
 
+// Only for SendMessageSingle():
+const int CHAT_CHANNEL_DM_TALK     = 17;
+const int CHAT_CHANNEL_DM_WHISPER  = 19;
+
 struct chat_message
 {
     int    Mode;
@@ -18,6 +22,12 @@ struct chat_message
 //Send chat message
 //nChannel - CHAT_CHANNEL_*
 int NWNXChat_SendMessage(object oSender, int nChannel, string sMessage, object oRecipient=OBJECT_INVALID);
+
+//Send chat message
+//mode - CHAT_CHANNEL_* (not all work)
+//sendTo - player object to which to send to the message packet
+//oSender - speaker (player or non-player)
+int NWNXChat_SendMessageSingle(int mode, object sendTo, object oSender, string sMessage);
 
 
 string GetStringFrom(string s, int from = 1)
@@ -109,6 +119,20 @@ int NWNXChat_SendMessage(object oSender, int nChannel, string sMessage, object o
     if(GetLocalString(oSender, "NWNX!CHAT!SPEAK")=="1") return TRUE;
     else return FALSE;
 }
+
+int NWNXChat_SendMessageSingle(int mode, object sendTo, object oSender, string sMessage)
+{
+    if (!GetIsObjectValid(sendTo)) return FALSE;
+    if (!GetIsPC(sendTo)) return FALSE;
+    if (!GetIsObjectValid(oSender)) return FALSE;
+    if (FindSubString(sMessage, "¬")!=-1) return FALSE;
+    
+    SetLocalString(oSender, "NWNX!CHAT!SENDMSGSINGLE", IntToString(mode)+"¬"+ObjectToString(sendTo)+"¬"+ObjectToString(oSender)+"¬"+sMessage);
+    if(GetLocalString(oSender, "NWNX!CHAT!SENDMSGSINGLE")=="1") return TRUE;
+    else return FALSE;
+}
+
+
 
 void NWNXChat_SendMessageVoid(object oSender, int nChannel, string sMessage, object oRecipient=OBJECT_INVALID)
 {


### PR DESCRIPTION
This patch to plugins/chat allows sending individual messages to clients (possibly overriding the global chat handler & doing it yourself).

Please check for noob errors before merging.
