### PR TITLE
plugins/chat: GetActualGameObjectForPC()

### DIFF
--- a/plugins/chat/HookChat.cpp
+++ b/plugins/chat/HookChat.cpp
@@ -50,6 +50,7 @@ int (*CNWSMessage__SendServerToPlayerChat_Party)(void* pCNWSMessage, int obj1, i
 int (*CNWSMessage__SendServerToPlayerChat_DM_Talk)(void* pCNWSMessage, int obj1, int obj2, CExoString* str);
 int (*CNWSMessage__SendServerToPlayerChat_DM_Whisper)(void* pCNWSMessage, int obj1, int obj2, CExoString* str);
 void *(*pGetServerMessage)(void *pServerExo);
+int (*CServerExoApp__GetClientObjectByObjectId)(void* pServerExo, unsigned long objectId);
 
 char scriptRun = 0;
 char *lastMsg;
@@ -301,6 +302,17 @@ unsigned long GetID(dword OID)
 	return *(pcObj);
 }
 
+
+unsigned long ResolveClientGameObjectByPCID(int nPlayerID)
+{
+    CNWSClient *pClient = (CNWSClient *) CServerExoApp__GetClientObjectByPlayerId(pServerExo, nPlayerID, 0);
+
+    if (!pClient)
+        return OBJECT_INVALID;
+
+    return pClient->GameObjectID;
+}
+
 void
 d_enable_write (unsigned long location)
 {
@@ -360,6 +372,8 @@ int HookFunctions()
     *(dword*)&CNWSMessage__SendServerToPlayerChat_Party = 0x8068fe4;
     *(dword*)&CNWSMessage__SendServerToPlayerChat_DM_Talk = 0x8069248;
     *(dword*)&CNWSMessage__SendServerToPlayerChat_DM_Whisper = 0x806a03c;
+
+    *(dword*)&CServerExoApp__GetClientObjectByObjectId = 0x080b24b8;
 
 	if (org_Run) {
 		*(dword*)&pRunScript = org_Run;

--- a/plugins/chat/HookChat.h
+++ b/plugins/chat/HookChat.h
@@ -36,6 +36,8 @@ unsigned long GetID(dword OID);
 int SendMsg(const int mode, const int id, char *msg, const int to);
 int SendMsgSingle(const int mode, const int conn, const int speaker, char *msg);
 
+unsigned long ResolveClientGameObjectByPCID(int playerId);
+
 extern char scriptRun;
 extern char *lastMsg;
 extern char lastIDs[];

--- a/plugins/chat/NWNXChat.cpp
+++ b/plugins/chat/NWNXChat.cpp
@@ -39,6 +39,8 @@ CNWNXChat::CNWNXChat()
   processNPC = 0;
   ignore_silent = 0;
   maxMsgLen = 1024;
+
+  resolveameObjectByIDReq = OBJECT_INVALID;
 }
 
 CNWNXChat::~CNWNXChat()
@@ -185,6 +187,11 @@ char* CNWNXChat::OnRequest (char* gameObject, char* Request, char* Parameters)
     Log(3, "o GETID: oID='%s', ID=%s\n", Parameters, LastID);
     return LastID;
   }
+  else if (strncmp(Request, "GETGAMEOBJRQ", 12) == 0)
+  {
+    int pcID = atoi(Parameters);
+    resolveameObjectByIDReq = ResolveClientGameObjectByPCID(pcID);
+  }
   else if (strncmp(Request, "LOGNPC", 6) == 0)
   {
 	  Log(3, "o LOGNPC: %s\n", Parameters);
@@ -243,6 +250,15 @@ char* CNWNXChat::OnRequest (char* gameObject, char* Request, char* Parameters)
       supressMsg = 1;
   }
   return NULL;
+}
+
+unsigned long CNWNXChat::OnRequestObject(char *gameObject, char *Request)
+{
+  if (strncmp(Request, "GETGAMEOBJ", 10) == 0)
+  {
+    return resolveameObjectByIDReq;
+  }
+  return OBJECT_INVALID;
 }
 
 bool CNWNXChat::OnRelease ()

--- a/plugins/chat/NWNXChat.h
+++ b/plugins/chat/NWNXChat.h
@@ -33,6 +33,7 @@ public:
   ~CNWNXChat();
   bool OnCreate(gline *config, const char* LogDir);
   char* OnRequest(char* gameObject, char* Request, char* Parameters);
+  unsigned long OnRequestObject(char *gameObject, char *Request);
   bool OnRelease();
   int supressMsg;
   int maxMsgLen;
@@ -48,6 +49,8 @@ public:
 protected:
   char *SendMessage(char* Parameters);
   char *SendMessageSingle(char* Parameters);
+private:
+  unsigned long resolveameObjectByIDReq;
 };
 
 #endif

--- a/plugins/chat/nwn/nwnx_chat.nss
+++ b/plugins/chat/nwn/nwnx_chat.nss
@@ -29,6 +29,12 @@ int NWNXChat_SendMessage(object oSender, int nChannel, string sMessage, object o
 //oSender - speaker (player or non-player)
 int NWNXChat_SendMessageSingle(int mode, object sendTo, object oSender, string sMessage);
 
+// Returns the actual game object for a client, for example possessed familiars.
+// Depends on you calling NWNXChat_PCEnter/Exit() appropriately.
+object NWNXChat_GetActualGameObjectForPC(object player);
+
+// Returns the actual game object for a client, for example possessed familiars.
+object NWNXChat_GetActualGameObjectForPlayerID(int playerId);
 
 string GetStringFrom(string s, int from = 1)
 {
@@ -149,4 +155,14 @@ int NWNXChat_GetCCMessagSubtype()
 {
     SetLocalString(GetModule(), "NWNX!CHAT!SUBTYPE", "  ");
     return StringToInt(GetLocalString(GetModule(), "NWNX!CHAT!SUBTYPE"));
+}
+
+object NWNXChat_GetActualGameObjectForPC(object player)
+{
+  return NWNXChat_GetActualGameObjectForPlayerID(GetLocalInt(player, PC_ID_NAME));
+}
+object NWNXChat_GetActualGameObjectForPlayerID(int playerId)
+{
+  SetLocalString(GetModule(), "NWNX!CHAT!GETGAMEOBJRQ", IntToString(playerId) + " ");
+  return GetLocalObject(GetModule(), "NWNX!CHAT!GETGAMEOBJ");
 }


### PR DESCRIPTION
This returns the actual game object for a player character (a object in
the range 0x7f000001 -> 0x7fffffff); for example a familiar or DM-possessed
creature. You can think of this as the reverse of GetMaster() for possessed
creatures.

Example usage: iterating players with GetFirst/NextPC() and finding the actual
controlled creature.