### PR TITLE
plugins/chat: use connection id for target instead of object_id

### DIFF
--- a/plugins/chat/NWNXChat.cpp
+++ b/plugins/chat/NWNXChat.cpp
@@ -156,12 +156,7 @@ char *CNWNXChat::SendMessageSingle(char* Parameters)
     return "0";
     }
 
-  int nRecipientID = GetID(oSendTo);
-  if(oSendTo <= 0x7F000000) {
-    Log(3, "o oSendTo is not a PC\n");
-    delete[] sMessage;
-    return "0";
-  }
+  int nRecipientID = oSendTo;
 
   strncpy(sMessage, nLastDelimiter+1, nMessageLen-1);
 

--- a/plugins/chat/nwn/nwnx_chat.nss
+++ b/plugins/chat/nwn/nwnx_chat.nss
@@ -124,10 +124,11 @@ int NWNXChat_SendMessageSingle(int mode, object sendTo, object oSender, string s
 {
     if (!GetIsObjectValid(sendTo)) return FALSE;
     if (!GetIsPC(sendTo)) return FALSE;
+    int nSendToID = NWNXChatGetPCID(sendTo);
     if (!GetIsObjectValid(oSender)) return FALSE;
     if (FindSubString(sMessage, "¬")!=-1) return FALSE;
     
-    SetLocalString(oSender, "NWNX!CHAT!SENDMSGSINGLE", IntToString(mode)+"¬"+ObjectToString(sendTo)+"¬"+ObjectToString(oSender)+"¬"+sMessage);
+    SetLocalString(oSender, "NWNX!CHAT!SENDMSGSINGLE", IntToString(mode)+"¬"+IntToString(nSendToID)+"¬"+ObjectToString(oSender)+"¬"+sMessage);
     if(GetLocalString(oSender, "NWNX!CHAT!SENDMSGSINGLE")=="1") return TRUE;
     else return FALSE;
 }


### PR DESCRIPTION
This allows us to look up the connection IDs of familiars and
DM-possessed creatures, which would otherwise not have been possible,
since GetID on nwnx side returns OBJECT_INVALID for player objects
currently possessing something.

Bugfix for previous PR.
