### PR TITLE
plugins/coreevents: publish some core events via pluginlink

### DIFF
--- a/nwnx_modules.h
+++ b/nwnx_modules.h
@@ -1,6 +1,20 @@
 #ifndef NWNX_MODULES_H_
 #define NWNX_MODULES_H_
 
+/**
+ * Event: NWNX/Core/PluginsLoaded
+ * Provider: nwnx2
+ *
+ * Called when all plugins are loaded. Use this to hook your own events
+ * that other plugins may provide.
+ *
+ * Does not provide any event data.
+ */
+
+/**
+ * Events: NWServer/SCO, NWServer/RCO
+ * Provider: nwnx_odbc2
+ */
 typedef struct
 {
 	const char* database;
@@ -11,6 +25,10 @@ typedef struct
 }
 	SCORCOStruct;
 
+/**
+ * Event: NWNX/ResMan/DemandResource
+ * Provider: nwnx_resman
+ */
 typedef struct
 {
 	char* resref; // "whatever.uti"
@@ -19,5 +37,33 @@ typedef struct
 }
 	ResManDemandResStruct;
 
+/**
+ * Event: NWServer/RunScript
+ * Provider: nwnx_coreevents
+ *
+ * Called whenever anything executes a script by name.
+ */
+typedef struct
+{
+	/* The script filename, without extension */
+	char* resref;
+	/* the object Id which would be OBJECT_SELF in NWScript. */
+	unsigned long objectId;
+	/* 1 for top-level scripts */
+	int recursionLevel;
+	/* Set to true to suppress any nwscript by that name from executing. */
+	bool suppress;
+}
+	CoreEventRunScriptStruct;
+
+/**
+ * Event: NWServer/MainLoop
+ * Provider: nwnx_coreevents
+ *
+ * Can be used to run some code in the server main loop, which will be
+ * executed about 60 times per second.
+ *
+ * Does not provide any event data.
+ */
 
 #endif  // NWNX_MODULES_H_

--- a/plugins/coreevents/CMakeLists.txt
+++ b/plugins/coreevents/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_module(coreevents NWNXCoreEvents HookCoreEvents plugin-coreevents
+  ../../api/all ../../api/nwnsyms.S
+)

--- a/plugins/coreevents/HookCoreEvents.cpp
+++ b/plugins/coreevents/HookCoreEvents.cpp
@@ -1,0 +1,54 @@
+#include "HookCoreEvents.h"
+#include "NWNXCoreEvents.h"
+#include "../../api/all.h"
+#include "../../include/nx_hook.h"
+
+HANDLE hMainLoopInner;
+HANDLE hRunScript;
+
+int (*CServerExoApp__MainLoopInner)(void *pServer);
+int (*CVirtualMachine__RunScript)(CVirtualMachine *cVM, CExoString *s, dword objectId,
+								  int recursionLevel);
+
+int Hook_MainLoopInner(void *pServer)
+{
+	int ret = CServerExoApp__MainLoopInner(pServer);
+
+	NotifyEventHooks(hMainLoopInner, 0, 0);
+
+	return ret;
+}
+
+int Hook_RunScript(CVirtualMachine *cVM, CExoString *s, dword objectId, int recursionLevel)
+{
+	if (s == NULL || s->IsEmpty())
+		return 0;
+
+	CoreEventRunScriptStruct info = {
+		s->Text, objectId, recursionLevel, false
+	};
+
+	NotifyEventHooks(hRunScript, (WPARAM)&info, 0);
+
+	if (!info.suppress)
+		return CVirtualMachine__RunScript(g_pVirtualMachine, s, objectId, recursionLevel);
+
+	/* Always clear the stack, just in case. This is what RunScript() does as well. */
+	g_pVirtualMachine->Stack.ClearStack();
+
+	return 1;
+}
+
+int HookFunctions()
+{
+	*(void **)&CServerExoApp__MainLoopInner = nx_hook_function((void *)0x080B2050,
+			(void *)Hook_MainLoopInner, 9, NX_HOOK_DIRECT | NX_HOOK_RETCODE);
+
+	*(void **)&CVirtualMachine__RunScript = nx_hook_function((void *)0x08261f94,
+			(void *)Hook_RunScript, 5, NX_HOOK_DIRECT | NX_HOOK_RETCODE);
+
+	hMainLoopInner = CreateHookableEvent("NWServer/MainLoop");
+	hRunScript = CreateHookableEvent("NWServer/RunScript");
+
+	return true;
+}

--- a/plugins/coreevents/HookCoreEvents.h
+++ b/plugins/coreevents/HookCoreEvents.h
@@ -1,0 +1,10 @@
+#if !defined(HookCoreEvents_h_)
+#define HookCoreEvents_h_
+
+typedef unsigned long dword;
+typedef unsigned short int word;
+typedef unsigned char byte;
+
+int HookFunctions();
+
+#endif

--- a/plugins/coreevents/NWNXCoreEvents.cpp
+++ b/plugins/coreevents/NWNXCoreEvents.cpp
@@ -1,0 +1,31 @@
+#include "NWNXCoreEvents.h"
+#include "HookCoreEvents.h"
+
+CNWNXCoreEvents::CNWNXCoreEvents() {
+    confKey = strdup("COREEVENTS");
+}
+
+CNWNXCoreEvents::~CNWNXCoreEvents() {
+}
+
+char* CNWNXCoreEvents::OnRequest (char* gameObject, char* Request, char* Parameters)
+{
+    return NULL;
+}
+
+bool CNWNXCoreEvents::OnCreate (gline *config, const char *LogDir)
+{
+    char log[128];
+
+    sprintf(log, "%s/nwnx_coreevents.txt", LogDir);
+
+    /* call the base class create function */
+    if (!CNWNXBase::OnCreate(config, log))
+        return false;
+
+    HookFunctions();
+
+    return true;
+}
+
+/* vim: set sw=4: */

--- a/plugins/coreevents/NWNXCoreEvents.h
+++ b/plugins/coreevents/NWNXCoreEvents.h
@@ -1,0 +1,21 @@
+#ifndef NWNX_COREEVENTS_H
+#define NWNX_COREEVENTS_H
+
+#include "NWNXBase.h"
+
+class CNWNXCoreEvents: public CNWNXBase
+{
+public:
+	CNWNXCoreEvents();
+	virtual ~ CNWNXCoreEvents();
+
+	bool OnCreate(gline *nwnxConfig, const char *LogDir = NULL);
+	char *OnRequest(char *gameObject, char *Request, char *Parameters);
+
+private:
+
+};
+
+#endif /* NWNX_COREEVENTS_H */
+
+/* vim: set sw=4: */

--- a/plugins/coreevents/plugin-coreevents.cpp
+++ b/plugins/coreevents/plugin-coreevents.cpp
@@ -1,0 +1,33 @@
+#include "NWNXCoreEvents.h"
+
+CNWNXCoreEvents nwnx_coreevents;
+PLUGINLINK *pluginLink = 0;
+
+PLUGININFO pluginInfo = {
+	sizeof(PLUGININFO),
+	"NWNXCoreEvents",
+	PLUGIN_MAKE_VERSION(0, 0, 0, 1),
+	"",
+	"niv",
+	"n@e-ix.net",
+	"MIT licence",
+	"",
+	0 //not transient
+};
+
+
+extern "C" PLUGININFO *GetPluginInfo(DWORD nwnxVersion)
+{
+	return &pluginInfo;
+}
+
+extern "C" int InitPlugin(PLUGINLINK *link)
+{
+	pluginLink = link;
+	return 0;
+}
+
+extern "C" CNWNXBase *GetClassObject()
+{
+	return &nwnx_coreevents;
+}


### PR DESCRIPTION
For now, only exposes the main loop (MainLoopInner actually), and
RunScript, which can be used to suppress/redirect script execution
events.

Also adds some documentation in nwnx_modules.h