### PR TITLE
Fix memory crashes for minimaps when players are offline during dynamic area load

### DIFF
--- a/plugins/areas/HookFunc.cpp
+++ b/plugins/areas/HookFunc.cpp
@@ -255,6 +255,15 @@ void NWNXSetAreaName(CNWSArea *pArea, char *sNewName)
 	UpdateAreasForDMs();
 }
 
+void InitMiniMap(CNWSCreature *pObject, int nIndex, dword nAreaID)
+{
+	void *pMinimap = new char[0x80];
+	memset(pMinimap, 0, 0x80);
+	pObject->AreaMiniMaps[nIndex] = pMinimap;
+	CExoArrayList_unsigned_long___Add(&pObject->AreaList, nAreaID);
+	areas.Log(1, "(catchup) initialized minimap for area id: %x\n", nAreaID);
+}
+
 // catchup players who did not get the dynamically loaded areas due to being offline
 void NWNXCatchupAreas(void *vModule, dword *nAreaIDs, int nDynamicAreas)
 {

--- a/plugins/areas/HookFunc.cpp
+++ b/plugins/areas/HookFunc.cpp
@@ -255,6 +255,43 @@ void NWNXSetAreaName(CNWSArea *pArea, char *sNewName)
 	UpdateAreasForDMs();
 }
 
+// catchup players who did not get the dynamically loaded areas due to being offline
+void NWNXCatchupAreas(void *vModule, dword *nAreaIDs, int nDynamicAreas)
+{
+	CNWSModule *pModule = (CNWSModule *)vModule;
+	if(!pServThis) InitConstants();
+	CGameObjectArray *pGameObjArray = CServerExoApp__GetObjectArray((void *)pServThis);
+	int nStaticAreas = pModule->Areas.Count - nDynamicAreas;
+	areas.Log(1, "(catchup) dynamic count: %d\n", nDynamicAreas);
+	if(!pGameObjArray) return;
+	for(int i=0; i<=0xFFF; i++)
+	{
+		CGameObjectArrayElement **pObjects = pGameObjArray->Objects;
+		CGameObjectArrayElement *pElement = pObjects[i];
+		if(!pElement) continue;
+		CNWSCreature *pObject = (CNWSCreature *) pElement->Object;
+		if(!pObject) continue;
+		if(pObject->Object.ObjectType == 5)
+		{
+			if(pObject->AreaMiniMaps)
+			{
+				if ( pObject->AreaCount < pModule->Areas.Count )
+				{
+					areas.Log(1, "Catchup for creature '%x'\n", pObject->Object.ObjectID);
+					pObject->AreaMiniMaps = (void **) realloc(pObject->AreaMiniMaps, pModule->Areas.Count * 4);
+					int nAreaDiff = pModule->Areas.Count - pObject->AreaCount;
+					for ( int i = pObject->AreaCount; i < pModule->Areas.Count; i++ )
+					{
+						int catchupIndex = i - nStaticAreas; // index into ordered dynamic area ids
+						InitMiniMap(pObject, i, nAreaIDs[catchupIndex]);
+					}
+					pObject->AreaCount = pModule->Areas.Count;
+				}
+			}	
+		}
+	}
+}
+
 int HookFunctions()
 {
 	ppServThis = 0x0832F1F4;

--- a/plugins/areas/HookFunc.h
+++ b/plugins/areas/HookFunc.h
@@ -33,6 +33,7 @@ void AddAreaToAllCreatures(dword nAreaID);
 void NWNXCreateArea(void *pModule, char *sResRef);
 void NWNXDestroyArea(void *pModule, dword nAreaID);
 void NWNXSetAreaName(CNWSArea *pArea, char *sNewName);
+void NWNXCatchupAreas(void *pModule, dword *nAreaIDs, int nDynamicAreas);
 
 void InitConstants();
 

--- a/plugins/areas/nwnx_areas.nss
+++ b/plugins/areas/nwnx_areas.nss
@@ -11,11 +11,26 @@ void DestroyArea(object oArea);
 // Set name for oArea
 void SetAreaName(object oArea, string sName);
 
+const string DYN_AREA_POINTERS = "dyn_ptrs";
 
 object LoadArea(string sResRef)
 {
     SetLocalString(GetModule(), "NWNX!AREAS!CREATE_AREA", sResRef);
-    return GetLocalObject(GetModule(), "NWNX!AREAS!GET_LAST_AREA_ID");
+    object area = GetLocalObject(GetModule(), "NWNX!AREAS!GET_LAST_AREA_ID");
+    
+    if ( area != OBJECT_INVALID ) {
+        object mod = GetModule();
+        string pointers = GetLocalString(mod, DYN_AREA_POINTERS);
+        string ptr = ObjectToString(area);
+        int len;
+        for ( len = GetStringLength(ptr); len < 8; len++ )
+        {
+            ptr = "0" + ptr;
+        }
+        SetLocalString(mod, DYN_AREA_POINTERS, pointers + ptr);
+    }
+    
+    return area;
 }
 
 object CreateArea(string sResRef)
@@ -26,9 +41,15 @@ object CreateArea(string sResRef)
 void DestroyArea(object oArea)
 {
     SetLocalString(GetModule(), "NWNX!AREAS!DESTROY_AREA", ObjectToString(oArea));
+    // TODO: Remove area pointer from pointer string ... 
 }
 
 void SetAreaName(object oArea, string sName)
 {
     SetLocalString(oArea, "NWNX!AREAS!SET_AREA_NAME", sName);
+}
+
+void CatchupAreas()
+{
+    SetLocalString(GetModule(), "NWNX!AREAS!CATCHUP_AREAS", GetLocalString(GetModule(), DYN_AREA_POINTERS));
 }

--- a/plugins/areas/nwnx_areas.nss
+++ b/plugins/areas/nwnx_areas.nss
@@ -50,7 +50,7 @@ void SetAreaName(object oArea, string sName)
 }
 
 // Call whenever someone joins the module.
-// This might sound expensive, but it will only reallocate memory if someone doesn't yet have all the dynamic areas.
+// This might sound expensive, but it will only reallocate minimaps/etc if someone doesn't have all the areas.
 void CatchupAreas()
 {
     SetLocalString(GetModule(), "NWNX!AREAS!CATCHUP_AREAS", GetLocalString(GetModule(), DYN_AREA_POINTERS));

--- a/plugins/areas/nwnx_areas.nss
+++ b/plugins/areas/nwnx_areas.nss
@@ -49,6 +49,8 @@ void SetAreaName(object oArea, string sName)
     SetLocalString(oArea, "NWNX!AREAS!SET_AREA_NAME", sName);
 }
 
+// Call whenever someone joins the module.
+// This might sound expensive, but it will only reallocate memory if someone doesn't yet have all the dynamic areas.
 void CatchupAreas()
 {
     SetLocalString(GetModule(), "NWNX!AREAS!CATCHUP_AREAS", GetLocalString(GetModule(), DYN_AREA_POINTERS));


### PR DESCRIPTION
This fixes a memory related crash under the following conditions:

- player joins server
- player leaves server
- dynamic area is loaded  (only players currently online have their minimap updated)
- player rejoins server
- player loads that area

My solution is to keep track of which dynamic areas have been added to the module.  When a player joins, we see if we need to add dynamic areas to anyone to catch them up.

It could probably be streamlined.  For example, I don't know how to get the dword pointer/area id from pModule's Areas member.  If this is possible, then we would not need to pass in all the areas ever dynamically created and it would simplify the code considerably.   It could also just be run against the player that has joined ... but I'm not sure how to get that pointer.   Looping through the other players to see that they have the right # of areas is probably not that expensive anyway.

It might also be possible to write the new minimap to all offline players? If so, this would be the simplest solution by far and we wouldn't need a new 'catchup_areas' function.

A new hook to 'pre load area' that could check if that area was dynamic and missing from the player's minimap & add it just in time could also improve efficiency over checking on login, but not sure that is necessary.