### PR TITLE
Update cmake build to support out of source tree builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,13 @@
 cmake_minimum_required(VERSION 2.8)
 project(nwnx-core-2.8)
 
+set(NWNX_OUTPUT_DIR ${PROJECT_BINARY_DIR}/compiled)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${NWNX_OUTPUT_DIR})
+
 # You can exclude plugins from being built here.
-set(dont_build_plugins )
+set(dont_build_plugins
+
+)
 
 # Compatibility with cmake 2.8.9 and above.
 if(POLICY CMP0018)
@@ -35,6 +40,19 @@ add_library(nwnx2 SHARED nwnx2lib NWNXBase modules lists gline
 	lib/nwn_data lib/nwn_funcs lib/nwn_hooks
 	lib/nx_hook lib/nx_log lib/nx_safe lib/nx_signature
 )
+
+# Fake target to force recreating the compiled directory.
+add_custom_target(always_rebuild_compiled ALL
+    COMMAND ${CMAKE_COMMAND} -E remove_directory ${NWNX_OUTPUT_DIR}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${NWNX_OUTPUT_DIR}
+)
+
+add_custom_command(
+    TARGET nwnx2 POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy ARGS ${PROJECT_SOURCE_DIR}/nwnx2.ini ${NWNX_OUTPUT_DIR}
+    COMMAND ${CMAKE_COMMAND} -E copy ARGS ${PROJECT_SOURCE_DIR}/nwnstartup.sh ${NWNX_OUTPUT_DIR}
+)
+
 set_target_properties(nwnx2 PROPERTIES PREFIX "")
 target_link_libraries(nwnx2 dl z)
 
@@ -46,11 +64,12 @@ function(add_module target)
 	set_target_properties(${target} PROPERTIES PREFIX "nwnx_")
 endfunction()
 
-function(add_gperf_target gperf v k l)
+function(add_gperf_target target gperf v k l)
 	add_custom_command(
-		OUTPUT "${gperf}.h"
-		COMMAND ${PROJECT_SOURCE_DIR}/plugins/gperf_gen.sh "${v}" "${k}" "${l}"
-		DEPENDS ${PROJECT_SOURCE_DIR}/plugins/gperf_gen.sh "${gperf}.gperf"
+                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/plugins/${target}
+                OUTPUT "${PROJECT_SOURCE_DIR}/plugins/${target}/${gperf}.h"
+                COMMAND ${PROJECT_SOURCE_DIR}/plugins/gperf_gen.sh "${v}" "${k}" "${l}"
+                DEPENDS ${PROJECT_SOURCE_DIR}/plugins/gperf_gen.sh "${gperf}.gperf"
 	)
 endfunction()
 
@@ -60,6 +79,15 @@ foreach(plugin ${plugins})
 
 	list(FIND dont_build_plugins ${na} dontbuild)
 	if (${dontbuild} EQUAL -1)
+        if(EXISTS "${pa}/nwnx2.ini")
+             add_custom_command(
+                 TARGET nwnx2 POST_BUILD
+                 COMMAND echo ARGS "" >> ${NWNX_OUTPUT_DIR}/nwnx2.ini
+                 COMMAND echo ARGS "" >> ${NWNX_OUTPUT_DIR}/nwnx2.ini
+                 COMMAND cat ARGS ${pa}/nwnx2.ini >> ${NWNX_OUTPUT_DIR}/nwnx2.ini
+             )
+        endif(EXISTS "${pa}/nwnx2.ini")
+
 		add_subdirectory(${pa})
 	else (${dontbuild} EQUAL -1)
 		message(STATUS "Skipping plugin ${na} due to configuration")

--- a/compile.sh
+++ b/compile.sh
@@ -41,26 +41,8 @@ Press enter to begin.
 
 read x
 
-rm -r compiled || true
-
 cmake .
 make all
-
-mkdir -vp compiled/
-
-cp -v ./nwnstartup.sh ./compiled/
-cp -v ./nwnx2.ini ./compiled/
-for p in plugins/*/; do
-	if [ -f $p/*.so ]; then
-		if [ -f $p/nwnx2.ini ]; then
-			echo ""  >> ./compiled/nwnx2.ini
-			echo ""  >> ./compiled/nwnx2.ini
-			cat $p/nwnx2.ini >> ./compiled/nwnx2.ini
-		fi
-	fi
-done
-mv -v ./plugins/*/*.so ./compiled/
-mv -v ./nwnx2.so ./compiled/
 
 echo "
 =====

--- a/plugins/defenses/CMakeLists.txt
+++ b/plugins/defenses/CMakeLists.txt
@@ -1,7 +1,7 @@
 if (gperf)
 
-add_gperf_target(DefensesStrCmds DefensesStr DEFENSES STR)
-add_gperf_target(DefensesObjCmds DefensesObj DEFENSES OBJ)
+add_gperf_target(defenses DefensesStrCmds DefensesStr DEFENSES STR)
+add_gperf_target(defenses DefensesObjCmds DefensesObj DEFENSES OBJ)
 
 include_directories(.)
 add_module(defenses NWNXDefenses plugin-defenses

--- a/plugins/funcs/CMakeLists.txt
+++ b/plugins/funcs/CMakeLists.txt
@@ -1,7 +1,7 @@
 if (gperf)
 
-add_gperf_target(FuncsStrCmds FuncsStr FUNCS STR)
-add_gperf_target(FuncsObjCmds FuncsObj FUNCS OBJ)
+add_gperf_target(funcs FuncsStrCmds FuncsStr FUNCS STR)
+add_gperf_target(funcs FuncsObjCmds FuncsObj FUNCS OBJ)
 
 include_directories(.)
 add_module(funcs NWNXFuncs plugin-funcs

--- a/plugins/spells/CMakeLists.txt
+++ b/plugins/spells/CMakeLists.txt
@@ -1,7 +1,7 @@
 if (gperf)
 
-add_gperf_target(SpellsStrCmds SpellsStr SPELLS STR)
-add_gperf_target(SpellsObjCmds SpellsObj SPELLS OBJ)
+add_gperf_target(spells SpellsStrCmds SpellsStr SPELLS STR)
+add_gperf_target(spells SpellsObjCmds SpellsObj SPELLS OBJ)
 
 include_directories(.)
 add_module(spells NWNXSpells plugin-spells

--- a/plugins/structs/CMakeLists.txt
+++ b/plugins/structs/CMakeLists.txt
@@ -1,7 +1,7 @@
 if (gperf)
 
-add_gperf_target(StructsStrCmds StructsStr STRUCTS STR)
-add_gperf_target(StructsObjCmds StructsObj STRUCTS OBJ)
+add_gperf_target(structs StructsStrCmds StructsStr STRUCTS STR)
+add_gperf_target(structs StructsObjCmds StructsObj STRUCTS OBJ)
 
 include_directories(.)
 add_module(structs NWNXStructs plugin-structs

--- a/plugins/system/CMakeLists.txt
+++ b/plugins/system/CMakeLists.txt
@@ -1,7 +1,7 @@
 if (gperf)
 
-add_gperf_target(SystemStrCmds SystemStr SYSTEM STR)
-add_gperf_target(SystemObjCmds SystemObj SYSTEM OBJ)
+add_gperf_target(system SystemStrCmds SystemStr SYSTEM STR)
+add_gperf_target(system SystemObjCmds SystemObj SYSTEM OBJ)
 
 include_directories(.)
 add_module(system NWNXSystem plugin-system

--- a/plugins/tweaks/CMakeLists.txt
+++ b/plugins/tweaks/CMakeLists.txt
@@ -1,7 +1,7 @@
 if (gperf)
 
-add_gperf_target(TweaksStrCmds TweaksStr TWEAKS STR)
-add_gperf_target(TweaksObjCmds TweaksObj TWEAKS OBJ)
+add_gperf_target(tweaks TweaksStrCmds TweaksStr TWEAKS STR)
+add_gperf_target(tweaks TweaksObjCmds TweaksObj TWEAKS OBJ)
 
 include_directories(.)
 add_module(tweaks NWNXTweaks plugin-tweaks

--- a/plugins/weapons/CMakeLists.txt
+++ b/plugins/weapons/CMakeLists.txt
@@ -1,7 +1,7 @@
 if (gperf)
 
-add_gperf_target(WeaponsStrCmds WeaponsStr WEAPONS STR)
-add_gperf_target(WeaponsObjCmds WeaponsObj WEAPONS OBJ)
+add_gperf_target(weapons WeaponsStrCmds WeaponsStr WEAPONS STR)
+add_gperf_target(weapons WeaponsObjCmds WeaponsObj WEAPONS OBJ)
 
 include_directories(.)
 add_module(weapons NWNXWeapons plugin-weapons


### PR DESCRIPTION
This doesn't change anything for those who want to build in
the source tree or have any impact on the auto tools build
system.

- Add fake target to always rebuild compiled directory.
- Modify gperf commands to add an additional parameter for their
target name and update all CMakeLists.txt for plugins that use gperf.
- Move all compile.sh functionality possible to CMakeLists.txt.