### PR TITLE
Fix some warnings.

### DIFF
--- a/gline.cpp
+++ b/gline.cpp
@@ -30,12 +30,10 @@ int
 gline::parse(const char *fname)
 {
 
-    int i, j, pos, len;
+    int j, pos;
     string sect, line, key, value;
-
     ifstream in(fname);
 
-    i = 0;
     while (getline(in, line)) {
 
         // strip inline comments

--- a/plugins/defenses/funcs/f_GetDefenseOption.c
+++ b/plugins/defenses/funcs/f_GetDefenseOption.c
@@ -29,7 +29,7 @@ void Func_GetDefenseOption(CGameObject *ob, char *value)
     if (opt >= 0 && opt < NWNX_DEFENSES_OPTIONS_TABLE_SIZE)
         val = Table_DefenseOptions[opt];
 
-    snprintf(value, sizeof(value), "%d", val);
+    snprintf(value, strlen(value), "%d", val);
 }
 
 

--- a/plugins/defenses/funcs/f_SetDefenseOption.c
+++ b/plugins/defenses/funcs/f_SetDefenseOption.c
@@ -38,7 +38,7 @@ void Func_SetDefenseOption(CGameObject *ob, char *value)
         val = 0;
 
     Table_DefenseOptions[opt] = val;
-    snprintf(value, sizeof(value), "%d", val);
+    snprintf(value, strlen(value), "%d", val);
 }
 
 

--- a/plugins/events/HookFunc.cpp
+++ b/plugins/events/HookFunc.cpp
@@ -291,9 +291,9 @@ void ConditionalScriptHookProc()
         try {
             bool bFound = false;
             dword nCurrentNode = pConversation->CurrentNodeID;
-            for (int nEntry = 0; nEntry < pConversation->EntryListCount; nEntry++) {
+            for (size_t nEntry = 0; nEntry < pConversation->EntryListCount; nEntry++) {
                 CDialogEntry* pEntry = &pConversation->EntryList[nEntry];
-                for (int nReply = 0; nReply < pEntry->RepliesNum; nReply++) {
+                for (size_t nReply = 0; nReply < pEntry->RepliesNum; nReply++) {
                     if (&pEntry->RepliesList[nReply] == pStartingEntry) {
                         events.nNodeType = ReplyNode;
                         events.nCurrentNodeID = nReply;
@@ -305,9 +305,9 @@ void ConditionalScriptHookProc()
                 if (bFound == true) break;
             }
             if (bFound == false) {
-                for (int nReply = 0; nReply < pConversation->ReplyListCount; nReply++) {
+                for (size_t nReply = 0; nReply < pConversation->ReplyListCount; nReply++) {
                     CDialogReply* pReply = &pConversation->ReplyList[nReply];
-                    for (int nEntry = 0; nEntry < pReply->EntriesNum; nEntry++) {
+                    for (size_t nEntry = 0; nEntry < pReply->EntriesNum; nEntry++) {
                         if (&pReply->EntriesList[nEntry] == (CDialogReplyEntry *) pStartingEntry) {
                             events.nNodeType = EntryNode;
                             events.nCurrentNodeID = nEntry;
@@ -320,7 +320,7 @@ void ConditionalScriptHookProc()
                 }
             }
             if (bFound == false) {
-                for (int nStartingEntry_t = 0; nStartingEntry_t < pConversation->StartingListCount; nStartingEntry_t++) {
+                for (size_t nStartingEntry_t = 0; nStartingEntry_t < pConversation->StartingListCount; nStartingEntry_t++) {
                     if (&pConversation->StartingList[nStartingEntry_t] == pStartingEntry) {
                         events.nNodeType = StartingNode;
                         events.nCurrentNodeID = nStartingEntry_t;

--- a/plugins/events/NWNXEvents.h
+++ b/plugins/events/NWNXEvents.h
@@ -67,7 +67,7 @@ public:
     dword oTarget;
     dword oItem;
     CNWSDialogClass *pConversation;
-    int nSelectedNodeID;
+    unsigned int nSelectedNodeID;
     int nSelectedAbsoluteNodeID;
     int nCurrentAbsoluteNodeID;
     int nCurrentNodeID;

--- a/plugins/extend/Hooks.cpp
+++ b/plugins/extend/Hooks.cpp
@@ -259,7 +259,7 @@ static int Local_GetDEXMod_ipMaxDexBonusMod()
         if (pItem_1 != NULL) {
             if (CNWSItem__GetPropertyByTypeExists(pItem_1, confMaxDexterityBonus_ip, 0)) {
                 CNWItemProperty *IP;
-                for (int i = 0; i < pItem_1->field_1FC; i++) {
+                for (size_t i = 0; i < pItem_1->field_1FC; i++) {
                     IP = CNWSItem__GetPassiveProperty(pItem_1, i);
                     if (IP != NULL && IP->ip_type == confMaxDexterityBonus_ip) {
                         if (IP->ip_cost_value != 9) {

--- a/plugins/fixes/FixesHooks.cpp
+++ b/plugins/fixes/FixesHooks.cpp
@@ -105,11 +105,11 @@ bool CompareVarLists(CNWObjectVarList *pVarList1, CNWObjectVarList *pVarList2)
     if (pVarList1->VarCount == 0 && pVarList2->VarCount == 0)
         return true;
 
-    for (int i = 0; i < pVarList1->VarCount; i++) {
+    for (size_t i = 0; i < pVarList1->VarCount; i++) {
         bool bFound = false;
         CNWObjectVarListElement *pVar1 = &pVarList1->VarList[i];
 
-        for (int j = 0; j < pVarList2->VarCount; j++) {
+        for (size_t j = 0; j < pVarList2->VarCount; j++) {
             CNWObjectVarListElement *pVar2 = &pVarList2->VarList[j];
 
             if (pVar1->nVarType == pVar2->nVarType &&
@@ -277,7 +277,7 @@ void PlayerListNoDMHook()
 int CNWSCreature__DoDamage_hook(CNWSCreature *a1, unsigned int a2)
 {
     fixes.Log(3, "DoDamage: %08lX, %d, Current: %d\n", a1->Object.ObjectID, a2, a1->Object.HitPoints);
-    if (a1->IsPC && a1->Object.HitPoints > 0 && a2 > a1->Object.HitPoints + 5) {
+    if (a1->IsPC && a1->Object.HitPoints > 0 && (int)a2 > a1->Object.HitPoints + 5) {
         a2 = a1->Object.HitPoints + 5;
         int ret = CNWSCreature__DoDamage(a1, a2);
         fixes.Log(3, "Running script...\n");

--- a/plugins/funcsext/NWNXFuncsExt.cpp
+++ b/plugins/funcsext/NWNXFuncsExt.cpp
@@ -70,8 +70,7 @@ void CNWNXFuncsExt::SetScript(CGameObject *ob, char* value)
         snprintf(value, strlen(value), "1");
         return;
     }
-
-    snprintf(value, strlen(value), "");
+    value[0] = 0;
 }
 
 void CNWNXFuncsExt::GetScript(CGameObject *ob, char* value)
@@ -132,7 +131,7 @@ void CNWNXFuncsExt::Set_IsGenericTrigger(CGameObject *ob, char* value)
     }
 
     SetIsGenericTrigger(ob->vtable->AsNWSTrigger(ob));
-    snprintf(value, strlen(value), "");
+    value[0] = 0;
 }
 
 void CNWNXFuncsExt::Set_IsAreaTransition(CGameObject *ob, char* value)
@@ -147,7 +146,7 @@ void CNWNXFuncsExt::Set_IsAreaTransition(CGameObject *ob, char* value)
     }
 
     SetIsAreaTransition(ob->vtable->AsNWSTrigger(ob));
-    snprintf(value, strlen(value), "");
+    value[0] = 0;
 }
 
 void CNWNXFuncsExt::Get_SurfaceMaterial(CGameObject *ob, char* value)

--- a/plugins/odmbc/NWNXodbc.cpp
+++ b/plugins/odmbc/NWNXodbc.cpp
@@ -175,9 +175,9 @@ BOOL CNWNXODBC::Reconnect()
     int error_code = reinterpret_cast<CMySQL*>(db)->GetErrorCode();
     if (bReconnectOnError &&
             dbType == dbMYSQL &&
-            error_code == CR_SERVER_GONE_ERROR ||
-            error_code == CR_CONNECTION_ERROR ||
-            error_code == CR_CONN_HOST_ERROR
+            (error_code == CR_SERVER_GONE_ERROR ||
+             error_code == CR_CONNECTION_ERROR ||
+             error_code == CR_CONN_HOST_ERROR)
        ) {
         if (db)
             db->Disconnect();
@@ -423,7 +423,7 @@ unsigned char * CNWNXODBC::ReadSCO(const char * database, const char * key, char
             key,
             player,
             NULL,
-            NULL
+            0
         };
         NotifyEventHooks(hRCOEvent, (uintptr_t) &rcoInfo);
 

--- a/plugins/serverlist/ServerlistHooks.cpp
+++ b/plugins/serverlist/ServerlistHooks.cpp
@@ -94,4 +94,5 @@ int HookFunctions()
     unsigned char *sendto_call = (unsigned char *) 0x082C791B;
     nx_hook_enable_write(sendto_call, 5);
     *(uint32_t *)(sendto_call + 1) = (uint32_t)sendto_hook - (uint32_t)(sendto_call + 5);
+    return 1;
 }

--- a/plugins/spells/funcs/f_GetSpellOption.c
+++ b/plugins/spells/funcs/f_GetSpellOption.c
@@ -29,7 +29,7 @@ void Func_GetSpellOption(CGameObject *ob, char *value)
     if (opt >= 0 && opt < NWNX_SPELLS_OPTIONS_TABLE_SIZE)
         val = Table_SpellOptions[opt];
 
-    snprintf(value, sizeof(value), "%d", val);
+    snprintf(value, strlen(value), "%d", val);
 }
 
 

--- a/plugins/spells/funcs/f_SetSpellOption.c
+++ b/plugins/spells/funcs/f_SetSpellOption.c
@@ -38,7 +38,7 @@ void Func_SetSpellOption(CGameObject *ob, char *value)
         val = 0;
 
     Table_SpellOptions[opt] = val;
-    snprintf(value, sizeof(value), "%d", val);
+    snprintf(value, strlen(value), "%d", val);
 }
 
 

--- a/plugins/tweaks/funcs/f_GetTweakOption.c
+++ b/plugins/tweaks/funcs/f_GetTweakOption.c
@@ -29,7 +29,7 @@ void Func_GetTweakOption(CGameObject *ob, char *value)
     if (opt >= 0 && opt < NWNX_TWEAKS_OPTIONS_TABLE_SIZE)
         val = Table_TweakOptions[opt];
 
-    snprintf(value, sizeof(value), "%d", val);
+    snprintf(value, strlen(value), "%d", val);
 }
 
 

--- a/plugins/tweaks/funcs/f_SetTweakOption.c
+++ b/plugins/tweaks/funcs/f_SetTweakOption.c
@@ -38,7 +38,7 @@ void Func_SetTweakOption(CGameObject *ob, char *value)
         val = 0;
 
     Table_TweakOptions[opt] = val;
-    snprintf(value, sizeof(value), "%d", val);
+    snprintf(value, strlen(value), "%d", val);
 }
 
 


### PR DESCRIPTION
Nothing that will potentially be replaced by 2.8 api has been changed.

* gline: Remove a couple unused variables.  There are still unsigned/signed
  issues here, but I'm not going to risk breaking anything.
* plugins/defenses, spells, tweaks: Fix argument to 'sizeof' in 'snprintf'
  using the size of char * rather than the size of the destination string.
  It works, but is a warning and there is no benefit to it.
* plugins/serverlist: Fix missing return value in HookFunctions.  Doesn't
  really need one, but might as well return something.
* plugins/fixes and events: Fix unsigned/signed comparison warnings.
* plugins/funcext: Fix a handle of sprintfs that are just setting string
  length to zero.
* plugins/odmbc: Clarify a boolean expression with parens.  Fix an int
  being initialized with NULL.