### PR TITLE
plugins/structs: add GetEffectNumIntegers(), fix possible mem clobbering

### DIFF
--- a/plugins/structs/CMakeLists.txt
+++ b/plugins/structs/CMakeLists.txt
@@ -12,6 +12,7 @@ add_module(structs NWNXStructs plugin-structs
 	funcs/f_GetDurationRemaining
 	funcs/f_GetHasEffect
 	funcs/f_GetInteger
+	funcs/f_GetNumIntegers
 	funcs/f_GetSpellId
 	funcs/f_GetTrueType
 	funcs/f_SetCreator

--- a/plugins/structs/NWNXStructs.h
+++ b/plugins/structs/NWNXStructs.h
@@ -33,6 +33,7 @@ void Func_GetDuration(CGameObject *ob, char *value);
 void Func_GetDurationRemaining(CGameObject *ob, char *value);
 void Func_GetHasEffect(CGameObject *ob, char *value);
 void Func_GetInteger(CGameObject *ob, char *value);
+void Func_GetNumIntegers(CGameObject *ob, char *value);
 void Func_GetSpellId(CGameObject *ob, char *value);
 void Func_GetTrueType(CGameObject *ob, char *value);
 void Func_SetCreator(CGameObject *ob, char *value);

--- a/plugins/structs/StructsStrCmds.gperf
+++ b/plugins/structs/StructsStrCmds.gperf
@@ -38,6 +38,7 @@ GETDURATION,                            Func_GetDuration
 GETDURATIONREMAINING,                   Func_GetDurationRemaining
 GETHASEFFECT,                           Func_GetHasEffect
 GETINTEGER,                             Func_GetInteger
+GETNUMINTEGERS,                         Func_GetNumIntegers
 GETSPELLID,                             Func_GetSpellId
 GETTRUETYPE,                            Func_GetTrueType
 SETCREATOR,                             Func_SetCreator

--- a/plugins/structs/funcs/f_GetInteger.c
+++ b/plugins/structs/funcs/f_GetInteger.c
@@ -30,7 +30,7 @@ void Func_GetInteger(CGameObject *ob, char *value)
 
     idx = atoi(value);
 
-    if (idx < 0 || idx > 15) {
+    if (idx < 0 || idx >= eff->eff_num_integers) {
         snprintf(value, strlen(value), "%d", -1);
         return;
     }

--- a/plugins/structs/funcs/f_GetNumIntegers.c
+++ b/plugins/structs/funcs/f_GetNumIntegers.c
@@ -1,4 +1,3 @@
-
 /***************************************************************************
     NWNXFuncs.cpp - Implementation of the CNWNXFuncs class.
     Copyright (C) 2007 Doug Swarin (zac@intertex.net)
@@ -23,18 +22,11 @@
 extern volatile CGameEffect *Hook_Struct_Last;
 
 
-void Func_SetInteger(CGameObject *ob, char *value)
+void Func_GetNumIntegers(CGameObject *ob, char *value)
 {
-    int idx, val;
     CGameEffect *eff = (CGameEffect *)Hook_Struct_Last;
 
-    if (sscanf(value, "%d %d", &idx, &val) != 2)
-        return;
-
-    if (idx < 0 || idx >= eff->eff_num_integers)
-        return;
-
-    eff->eff_integers[idx] = val;
+    snprintf(value, strlen(value), "%d", eff->eff_num_integers);
 }
 
 

--- a/plugins/structs/nwnx_structs.nss
+++ b/plugins/structs/nwnx_structs.nss
@@ -248,9 +248,15 @@ float GetEffectDuration (effect eEffect);
  * DURATION_TYPE_TEMPORARY. */
 float GetEffectDurationRemaining (effect eEffect);
 
+/* Returns the number of effect integers the given effect has.
+ * This number is entirely dependant on the given effect type.
+ * By default, new CGameEffects have 8; but you need to check anyways.
+ */
+int GetEffectNumIntegers (effect eEffect);
+
 /* Returns the internal effect integer at the index specified. The index
- * is limited to being between 0 and 15, and which index contains what
- * value depends entirely on the type of effect. */
+ * is limited to being between 0 and GetEffectNumIntegers(), and which index
+ * contains what value depends entirely on the type of effect. */
 int GetEffectInteger (effect eEffect, int nIndex);
 
 /* Sets the internal effect integer at the specified index to the
@@ -296,6 +302,11 @@ float GetEffectDuration (effect eEffect) {
 float GetEffectDurationRemaining (effect eEffect) {
     SetLocalString(GetModule(), "NWNX!STRUCTS!GETDURATIONREMAINING", "          ");
     return StringToFloat(GetLocalString(GetModule(), "NWNX!STRUCTS!GETDURATIONREMAINING"));
+}
+
+int GetEffectNumIntegers (effect eEffect) {
+    SetLocalString(GetModule(), "NWNX!STRUCTS!GETNUMINTEGERS", "          ");
+    return StringToInt(GetLocalString(GetModule(), "NWNX!STRUCTS!GETNUMINTEGERS"));
 }
 
 int GetEffectInteger (effect eEffect, int nIndex) {


### PR DESCRIPTION
Plugin assumes 16 effect integers by default, which is wrong. Functions
would also allow writing over the array length with no checks, clobbering
the CGameEffect* struct and whatever else follows.

This patch adds GetEffectNumIntegers() to retrieve the array size and adds
safeguards to prevent clobbering the stack.

Please review before merging.