### PR TITLE
CScriptLocation and CNWSVector members need to be float

### DIFF
--- a/api/CScriptLocation.h
+++ b/api/CScriptLocation.h
@@ -11,12 +11,12 @@ public:
     ~CScriptLocation();
     CScriptLocation();
 
-    /* 0x0/0 */ unsigned long X;
-    /* 0x4/4 */ unsigned long Y;
-    /* 0x8/8 */ unsigned long Z;
-    /* 0xC/12 */ unsigned long OrientationX;
-    /* 0x10/16 */ unsigned long OrientationY;
-    /* 0x14/20 */ unsigned long OrientationZ;
+    /* 0x0/0 */ float X;
+    /* 0x4/4 */ float Y;
+    /* 0x8/8 */ float Z;
+    /* 0xC/12 */ float OrientationX;
+    /* 0x10/16 */ float OrientationY;
+    /* 0x14/20 */ float OrientationZ;
     /* 0x18/24 */ unsigned long AreaID;
 };
 #endif

--- a/api/nwnstructs.h
+++ b/api/nwnstructs.h
@@ -255,9 +255,9 @@ struct CVirtualMachineCommand {
     /* 0x4/4 */ void *Command;
 };
 struct CNWSVector {
-    /* 0x0/0 */ unsigned long X;
-    /* 0x4/4 */ unsigned long Y;
-    /* 0x8/8 */ unsigned long Z;
+    /* 0x0/0 */ float X;
+    /* 0x4/4 */ float Y;
+    /* 0x8/8 */ float Z;
 };
 struct CServerExoApp_vt {
     /* 0x0/0 */ unsigned long field_0;


### PR DESCRIPTION
This used to be okay, but breaks on gcc >= 4.9.2 (jessie). Numbers
are mangled when casting so incorrect values are reported to nwscript.

Testing level received: I've checked that all plugins still compile.