### PR TITLE
api/CExoArrayList: fields named incorrectly

### DIFF
--- a/api/CExoArrayList.h
+++ b/api/CExoArrayList.h
@@ -25,7 +25,13 @@ public:
     T & operator[](int);
 
     /* 0x0/0 */ T *Array;
-    /* 0x4/4 */ unsigned long nAllocatedSize;
-    /* 0x8/8 */ unsigned long nUsedSize;
+
+    /* You might have come here for compile errors regarding nAllocatedSize.
+     * The fields were labelled incorrectly, so they have been swapped.
+     * In order to not break plugins in subtle ways we've renamed them.
+     * You probably want "Length" now.
+     */
+    /* 0x4/4 */ unsigned long Length;
+    /* 0x8/8 */ unsigned long ArraySize;
 };
 #endif

--- a/plugins/connect/ConnectHooks.cpp
+++ b/plugins/connect/ConnectHooks.cpp
@@ -63,8 +63,8 @@ void SendHakList(CNWSMessage *pMessage, int nPlayerID)
     if (pModule) {
         plugin.Log(0, "Sending hak list...\n");
         pMessage->CreateWriteMessage(80, -1, 1);
-        pMessage->WriteINT(pModule->HakList.nAllocatedSize, 32);
-        for (int i = pModule->HakList.nAllocatedSize - 1; i >= 0; --i) {
+        pMessage->WriteINT(pModule->HakList.Length, 32);
+        for (int i = pModule->HakList.Length - 1; i >= 0; --i) {
             pMessage->WriteCExoString(pModule->HakList[i], 32);
             plugin.Log(0, "%s\n", pModule->HakList[i].Text);
         }


### PR DESCRIPTION
Field meaning has been swapped.

used length comes first, array alloc size after. Not the other way round.