### PR TITLE
pluginlink: GetRunningEventName() returns the current event inside hooks

### DIFF
--- a/modules.c
+++ b/modules.c
@@ -222,6 +222,13 @@ int SetHookDefaultForHookableEvent(HANDLE hEvent, NWNXHOOK pfnHook)
     return 0;
 }
 
+static char* currentEventName;
+
+const char *GetCurrentEventName()
+{
+    return currentEventName;
+}
+
 int CallHookSubscribers(HANDLE hEvent, uintptr_t pParam, bool abortable)
 {
     int i, returnVal = 0;
@@ -232,6 +239,10 @@ int CallHookSubscribers(HANDLE hEvent, uintptr_t pParam, bool abortable)
         //LeaveCriticalSection( &csHooks );
         return -1;
     }
+
+    char *oldCurrentEventName = currentEventName;
+
+    currentEventName = p->name;
 
     // NOTE: We've got the critical section while all this lot are called. That's mostly safe, though.
     for (i = 0; i < p->subscriberCount; i++) {
@@ -250,6 +261,8 @@ int CallHookSubscribers(HANDLE hEvent, uintptr_t pParam, bool abortable)
     // check for no hooks and call the default hook if any
     if (p->subscriberCount == 0 && p->pfnHook != 0)
         returnVal = p->pfnHook(pParam);
+
+    currentEventName = oldCurrentEventName;
 
     //LeaveCriticalSection(&csHooks);
     return returnVal;

--- a/modules.h
+++ b/modules.h
@@ -117,6 +117,15 @@ HANDLE HookEvent(const char *name, NWNXHOOK hookProc);
 */
 int UnhookEvent(HANDLE hHook);
 
+/**
+ * GetCurrentEventName
+ *
+ * Returns the currently running event name, or NULL if not in a event handler.
+ *
+ * In nested event handlers, only the topmost (current) one is ever returned.
+ */
+const char *GetCurrentEventName();
+
 
 /**
  * CreateServiceFunction

--- a/newpluginapi.h
+++ b/newpluginapi.h
@@ -40,6 +40,7 @@ typedef struct {
     int (*CallService)(const char *, uintptr_t);
     int (*ServiceExists)(const char *);       //v0.1.0.1+
     int (*SetHookDefaultForHookableEvent)(HANDLE, NWNXHOOK);  // v0.3.4 (2004/09/15)
+    const char* (*GetCurrentEventName)();
 } PLUGINLINK;
 
 #ifndef MODULES_H_
@@ -59,6 +60,7 @@ extern PLUGINLINK *pluginLink;
 #define CallService(a,b)                     pluginLink->CallService(a,b)
 #define ServiceExists(a)                     pluginLink->ServiceExists(a)
 #define SetHookDefaultForHookableEvent(a,b)  pluginLink->SetHookDefaultForHookableEvent(a,b)
+#define GetCurrentEventName()                pluginLink->GetCurrentEventName()
 #endif
 #endif
 

--- a/nwnx2lib.cpp
+++ b/nwnx2lib.cpp
@@ -662,6 +662,7 @@ void LoadCoreModule()
     pluginCoreLink.NotifyEventHooks = NotifyEventHooks;
     pluginCoreLink.NotifyEventHooksNotAbortable = NotifyEventHooksNotAbortable;
     pluginCoreLink.SetHookDefaultForHookableEvent = SetHookDefaultForHookableEvent;
+    pluginCoreLink.GetCurrentEventName = GetCurrentEventName;
     //pluginCoreLink.NotifyEventHooksDirect=CallHookSubscribers;
 
     hPluginsLoadedEvent = CreateHookableEvent(EVENT_CORE_PLUGINSLOADED);


### PR DESCRIPTION
This allows you to reuse event handlers for multiple events.