### PR TITLE
call CNWNXBase::OnPluginsLoaded() as shorthand to EVENT_CORE_PLUGINSLOADED

### DIFF
--- a/NWNXBase.cpp
+++ b/NWNXBase.cpp
@@ -53,6 +53,10 @@ bool CNWNXBase::OnCreate(gline *config, const char* LogFile)
     return (m_fFile != NULL);
 }
 
+void CNWNXBase::OnPluginsLoaded()
+{
+}
+
 bool CNWNXBase::OnRelease()
 {
     // close the log file

--- a/NWNXBase.h
+++ b/NWNXBase.h
@@ -47,6 +47,13 @@ public:
     virtual bool OnCreate(gline *nwnxConfig, const char* LogFile = NULL);
 
     ///////////////////////////////////////////////////////////////////////////
+    // Function: OnPluginsLoaded
+    // Description
+    //  OnPluginsLoaded is called at the same time when EVENT_CORE_ONPLUGINSLOADED
+    //  is sent out. You can use this instead of doing HookEvent(..) yourself.
+    virtual void OnPluginsLoaded();
+
+    ///////////////////////////////////////////////////////////////////////////
     // Function: OnRequest (char* Request, char* Parameters)
     // Description
     //	Called when a request is pending from a NWScript.

--- a/nwnx2lib.cpp
+++ b/nwnx2lib.cpp
@@ -715,6 +715,10 @@ startstop::startstop()
     LoadLibraries();
     NotifyEventHooksNotAbortable(hPluginsLoadedEvent, 0);
 
+    std::map<string, CNWNXBase*>::iterator it;
+    for (it = Libraries.begin(); it != Libraries.end(); it++)
+        it->second->OnPluginsLoaded();
+
     // log & emit
     Log(0, "* NWNX2 activated.\n");
 }


### PR DESCRIPTION
Just a tiny helper to make hooking other events more comfortable. No need to hook PLUGINSLOADED yourself, just handle it in the optional CNWNXBase virtual.