### PR TITLE
annotate api/CNWSObject|Module|Area->GetScriptVarTable() with proper type

### DIFF
--- a/api/CNWSArea.cpp
+++ b/api/CNWSArea.cpp
@@ -315,7 +315,7 @@ int CNWSArea::GetScriptName(int)
     asm("jmp *%eax");
 }
 
-int CNWSArea::GetScriptVarTable()
+CNWSScriptVarTable *  CNWSArea::GetScriptVarTable()
 {
     asm("leave");
     asm("mov $0x080d57e8, %eax");

--- a/api/CNWSArea.h
+++ b/api/CNWSArea.h
@@ -56,7 +56,7 @@ public:
     int GetOverrideWeather();
     unsigned char GetPVPSetting();
     int GetScriptName(int);
-    int GetScriptVarTable();
+    CNWSScriptVarTable * GetScriptVarTable();
     int GetSoundPathInformation();
     int GetSurfaceMaterial(Vector);
     CExoString GetTag();

--- a/api/CNWSModule.cpp
+++ b/api/CNWSModule.cpp
@@ -518,7 +518,7 @@ int CNWSModule::GetScriptName(int)
     asm("jmp *%eax");
 }
 
-int CNWSModule::GetScriptVarTable()
+CNWSScriptVarTable *  CNWSModule::GetScriptVarTable()
 {
     asm("leave");
     asm("mov $0x081c10e0, %eax");

--- a/api/CNWSModule.h
+++ b/api/CNWSModule.h
@@ -86,7 +86,7 @@ public:
     CNWSPlayerTURD * GetPlayerTURDFromList(CNWSPlayer *);
     unsigned long GetPrimaryPlayerIndex();
     int GetScriptName(int);
-    int GetScriptVarTable();
+    CNWSScriptVarTable * GetScriptVarTable();
     int GetStartMovie();
     CExoString GetTag();
     int GetTimeOfDayState();

--- a/api/CNWSObject.cpp
+++ b/api/CNWSObject.cpp
@@ -1022,7 +1022,7 @@ CScriptLocation CNWSObject::GetScriptLocation()
     asm("jmp *%eax");
 }
 
-int CNWSObject::GetScriptVarTable()
+CNWSScriptVarTable * CNWSObject::GetScriptVarTable()
 {
     asm("leave");
     asm("mov $0x081d5af4, %eax");

--- a/api/CNWSObject.h
+++ b/api/CNWSObject.h
@@ -158,7 +158,7 @@ public:
     int GetReputation(unsigned long, int &, int);
     int GetSavingThrowSpellId();
     CScriptLocation GetScriptLocation();
-    int GetScriptVarTable();
+    CNWSScriptVarTable * GetScriptVarTable();
     int GetSelectableWhenDead();
     CExoString * GetTag();
     CExoString * GetTemplate();
@@ -324,7 +324,7 @@ public:
     /* 0xD4/212 */ unsigned long Invulnerable;
     /* (mtype:CExoLinkedList<CNWSObjectActionNode>) */
     /* 0xD8/216 */ CExoLinkedList<CNWSObjectActionNode> ActionsList;
-    /* 0xDC/220 */ unsigned long ScriptVarTable;
+    /* 0xDC/220 */ CNWSScriptVarTable * ScriptVarTable;
     /* 0xE0/224 */ unsigned long field_E0;
     /* 0xE4/228 */ unsigned long field_E4;
     /* 0xE8/232 */ unsigned long field_E8;


### PR DESCRIPTION
Currently not used by any in-tree plugin but I'd want it upstream anyways!