### PR TITLE
plugins/mhash: support generating UUIDs

### DIFF
--- a/plugins/mhash/CMakeLists.txt
+++ b/plugins/mhash/CMakeLists.txt
@@ -1,12 +1,14 @@
-find_package(MHASH)
+find_library(MHASH_LIBRARY mhash)
+find_library(UUID_LIBRARY uuid)
 
-if (MHASH_FOUND)
+if (UUID_LIBRARY)
+if (MHASH_LIBRARY)
+add_module(mhash
+    NWNXMHash
+    plugin-mhash
+)
 
-	add_module(mhash
-	    NWNXMHash
-	    plugin-mhash
-	)
+target_link_libraries(mhash ${MHASH_LIBRARY} ${UUID_LIBRARY})
 
-	target_link_libraries(mhash ${MHASH_LIBRARY})
-
-endif (MHASH_FOUND)
+endif (MHASH_LIBRARY)
+endif (UUID_LIBRARY)

--- a/plugins/mhash/NWNXMHash.cpp
+++ b/plugins/mhash/NWNXMHash.cpp
@@ -110,7 +110,16 @@ char *CNWNXMHash::OnRequest(char *gameObject, char *Request, char *Parameters)
 
     /* MHASH!HASH algo¬data
      * MHASH!HMAC algo¬pass¬data
+     * MHASH!UUID
      */
+
+    if (strcmp("UUID", Request) == 0) {
+        uuid_t uuid;
+        uuid_generate(uuid);
+        char *uuid_s = (char*) malloc(37);
+        uuid_unparse_lower(uuid, uuid_s);
+        return uuid_s;
+    }
 
     char *p = strdup(Parameters);
     char *algo = strtok(p, "¬");

--- a/plugins/mhash/NWNXMHash.h
+++ b/plugins/mhash/NWNXMHash.h
@@ -5,6 +5,7 @@
 #include "NWNXBase.h"
 
 #include <mhash.h>
+#include <uuid/uuid.h>
 
 class CNWNXMHash : public CNWNXBase
 {

--- a/plugins/mhash/apt-dep
+++ b/plugins/mhash/apt-dep
@@ -1,1 +1,1 @@
-libmhash-dev
+libmhash-dev uuid-dev

--- a/plugins/mhash/nwnx_mhash.nss
+++ b/plugins/mhash/nwnx_mhash.nss
@@ -1,4 +1,18 @@
 /**
+ * Generates a UUID.
+ *
+ * The UUID will be of type v4 when a reliable source of random
+ * data is available; otherwise, it will be a v3 bound to your local
+ * MAC address.
+ *
+ * See uuid_generate(3) for details.
+ *
+ * Returned value is a 36-character UUID like so:
+ *   2f8e8c3e-61e0-4f97-b367-b9d5c8123693
+ */
+string mhash_uuid();
+
+/**
  * Hashes a string with a named algorithm.
  *
  * For a list of supported algorithms, read the mhash manpage of your distro, or have a look


### PR DESCRIPTION
What the label on the tin says.

```
/**
 * Generates a UUID.
 *
 * The UUID will be of type v4 when a reliable source of random
 * data is available; otherwise, it will be a v3 bound to your local
 * MAC address.
 *
 * See uuid_generate(3) for details.
 *
 * Returned value is a 36-character UUID like so:
 *   2f8e8c3e-61e0-4f97-b367-b9d5c8123693
 */
string mhash_uuid();
```
