### PR TITLE
core: add EVENT_CORE_MODULE_LOAD(ED|ING)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ add_library(nwnx2 SHARED nwnx2lib NWNXBase modules lists gline
 
     core/core
     core/events/Mainloop
+    core/events/Module
     core/events/RunScript
     core/events/Object
 )

--- a/core/core.cpp
+++ b/core/core.cpp
@@ -3,14 +3,16 @@
 PLUGINLINK *pluginLink;
 
 void Core_Mainloop_Init();
+void Core_Module_Init();
 void Core_RunScript_Init();
 void Core_Object_Init();
 
 void Core_Init(PLUGINLINK *link)
 {
-	pluginLink = link;
+    pluginLink = link;
 
-	Core_Mainloop_Init();
-	Core_RunScript_Init();
-	Core_Object_Init();
+    Core_Mainloop_Init();
+    Core_Module_Init();
+    Core_RunScript_Init();
+    Core_Object_Init();
 }

--- a/core/events/Module.cpp
+++ b/core/events/Module.cpp
@@ -1,0 +1,49 @@
+#include "../core.h"
+
+#include "NWNXApi.h"
+
+static HANDLE hModuleLoading, hModuleLoaded;
+
+/* Mid-function hook to load a new module. */
+static int CServerExoApp__LoadModule(
+    CServerExoApp *s,
+    CExoString mod,
+    int a3,
+    CNWSPlayer *p
+)
+{
+    CoreModuleLoadingEvent e = {
+        mod.CStr()
+    };
+
+    NotifyEventHooksNotAbortable(hModuleLoading, (uintptr_t) &e);
+
+    return s->LoadModule(mod, a3, p);
+}
+
+/* Obscure mid-function hook that is triggered on successful module load.
+ * Unlikely to conflict with other plugins. */
+static short CServerExoApp__GetServerMode(CServerExoApp *s)
+{
+    short ret = s->GetServerMode();
+
+    if (ret)
+        NotifyEventHooksNotAbortable(hModuleLoaded, 0);
+
+    return ret;
+}
+
+static inline void HookCall(DWORD src_addr, DWORD to_addr)
+{
+    nx_hook_enable_write((void*) src_addr, 5);
+    *(DWORD *)(src_addr + 1) = to_addr - (src_addr + 5);
+}
+
+void Core_Module_Init()
+{
+    hModuleLoading = CreateHookableEvent(EVENT_CORE_MODULE_LOADING);
+    hModuleLoaded = CreateHookableEvent(EVENT_CORE_MODULE_LOADED);
+
+    HookCall(0x0804e712, (DWORD) CServerExoApp__LoadModule);
+    HookCall(0x0804e77a, (DWORD) CServerExoApp__GetServerMode);
+}

--- a/core/pluginlink.h
+++ b/core/pluginlink.h
@@ -7,11 +7,35 @@
  * Param: NULL
  * Abortable: No
  *
- * Called after all modules have been loaded.
+ * Called after all plugins have been loaded.
  *
  * Best place to hook events provided by other modules inside plugins.
  */
 #define EVENT_CORE_PLUGINSLOADED "Core/PluginsLoaded"
+
+/**
+ * Event: EVENT_CORE_MODULE_LOADING
+ * Param: CoreModuleLoadingEvent
+ * Abortable: No
+ *
+ * Called when a new module is loading, either on startup or
+ * via the interactive commands.
+ */
+#define EVENT_CORE_MODULE_LOADING "Core/ModuleLoading"
+
+struct CoreModuleLoadingEvent {
+    const char *module;
+};
+
+/**
+ * Event: EVENT_CORE_MODULE_LOADED
+ * Param: NULL
+ * Abortable: No
+ *
+ * Called after a new module was loaded successfully, just
+ * before the first scripts run.
+ */
+#define EVENT_CORE_MODULE_LOADED "Core/ModuleLoaded"
 
 /**
  * Event: EVENT_CORE_RUNSCRIPT
@@ -24,17 +48,17 @@
 #define EVENT_CORE_RUNSCRIPT "Core/RunScript"
 
 struct CoreRunScriptEvent {
-	/* The script filename, without extension */
-	const char* resref;
-	/* the object Id which would be OBJECT_SELF in NWScript. */
-	const nwobjid objectId;
-	/* 1 for top-level scripts */
-	const int recursionLevel;
-	/* Set to true to suppress any nwscript by that name from executing. */
-	bool suppress;
-	/* Set the return value for conditional scripts. -1 for none, 0 for false,
-	 * 1 for true. */
-	int returnValue;
+    /* The script filename, without extension */
+    const char* resref;
+    /* the object Id which would be OBJECT_SELF in NWScript. */
+    const nwobjid objectId;
+    /* 1 for top-level scripts */
+    const int recursionLevel;
+    /* Set to true to suppress any nwscript by that name from executing. */
+    bool suppress;
+    /* Set the return value for conditional scripts. -1 for none, 0 for false,
+     * 1 for true. */
+    int returnValue;
 };
 
 /**
@@ -56,13 +80,13 @@ struct CoreRunScriptEvent {
 #define EVENT_CORE_RUNSCRIPT_SITUATION "Core/RunScriptSituation"
 
 struct CoreRunScriptSituationEvent {
-	/* The script filename, without extension */
-	char* marker;
-	uint32_t token;
-	/* the object Id which would be OBJECT_SELF in NWScript. */
-	nwobjid objectId;
-	/* Set to true to suppress any nwscript by that name from executing. */
-	bool suppress;
+    /* The script filename, without extension */
+    char* marker;
+    uint32_t token;
+    /* the object Id which would be OBJECT_SELF in NWScript. */
+    nwobjid objectId;
+    /* Set to true to suppress any nwscript by that name from executing. */
+    bool suppress;
 };
 
 /**
@@ -114,7 +138,7 @@ struct CoreRunScriptSituationEvent {
  */
 #define EVENT_CORE_OBJECT_CREATED "Core/CNWSObject/Created"
 struct ObjectCreatedEvent {
-	const void *object;
+    const void *object;
     const nwobjid requestedId;
 };
 
@@ -133,5 +157,5 @@ struct ObjectCreatedEvent {
  */
 #define EVENT_CORE_OBJECT_DESTROYED "Core/CNWSObject/Destroyed"
 struct ObjectDestroyedEvent {
-	const void *object;
+    const void *object;
 };


### PR DESCRIPTION
This embeds some in-function hooking. It's a bit messy but it shouldn't
conflict with any other plugins already messing with AdminLoadModule()

It also adds some static/inline helpers to do the actual hooking. We
might want to move them into a global include so every plugin can use them
but I couldn't be bothered to sort out the naming in this same PR.

Plz review thx xxxx