### PR TITLE
api: amend CGameEffect.h field types

### DIFF
--- a/api/CGameEffect.h
+++ b/api/CGameEffect.h
@@ -32,11 +32,10 @@ public:
     int operator==(CGameEffect const &) const;
     int operator!=(CGameEffect const &) const;
 
-    /* 0x0/0 */ unsigned long Id;
-    /* 0x4/4 */ unsigned long field_4;
+    /* 0x0/0 */ unsigned long long Id;
     /* 0x8/8 */ unsigned short Type;
     /* 0xA/10 */ unsigned short SubType;
-    /* 0xC/12 */ unsigned long Duration;
+    /* 0xC/12 */ float Duration;
     /* 0x10/16 */ unsigned long ExpireDay;
     /* 0x14/20 */ unsigned long ExpireTime;
     /* 0x18/24 */ unsigned long CreatorId;
@@ -44,10 +43,10 @@ public:
     /* 0x20/32 */ unsigned long IsExposed;
     /* 0x24/36 */ unsigned long IsIconShown;
     /* 0x28/40 */ unsigned long CasterLevel;
-    /* 0x2C/44 */ unsigned long LinkLeft;
-    /* 0x30/48 */ unsigned long LinkRight;
+    /* 0x2C/44 */ CGameEffect * LinkLeft;
+    /* 0x30/48 */ CGameEffect * LinkRight;
     /* 0x34/52 */ unsigned long NumIntegers;
-    /* 0x38/56 */ unsigned long IntList;
+    /* 0x38/56 */ long * IntList;
     /* 0x3C/60 */ float FloatList[4];
     /* 0x4C/76 */ CExoString StringList[6];
     /* 0x7C/124 */ unsigned long ObjectList[4];


### PR DESCRIPTION
This changes:

* the Id to be the actual uint64 it is supposed to be
* the lists to be array pointers
* the duration field to be a float (this is important for newer gccs)
* LinkLeft/LinkRight are now CGameEffect*

All plugins still compile fine, however I don't know if any custom/3rd party plugins might break on the id/field_04 change.