### PR TITLE
make -std=c++0x the project default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,17 @@ endif (NOT ruby)
 include_directories(lib include .)
 include_directories(plugins)
 
+include(CheckCXXCompilerFlag)
+CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
+if(COMPILER_SUPPORTS_CXX11)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+elseif(COMPILER_SUPPORTS_CXX0X)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+else()
+        message(SEND_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
+endif()
+
 add_library(nwnx2 SHARED nwnx2lib NWNXBase modules lists gline
 	lib/nwn_data lib/nwn_funcs lib/nwn_hooks
 	lib/nx_hook lib/nx_log lib/nx_safe lib/nx_signature

--- a/plugins/resman/CMakeLists.txt
+++ b/plugins/resman/CMakeLists.txt
@@ -1,4 +1,3 @@
 add_module(resman HookDemandRes NWNXResMan plugin-resman DirectoryHandler)
 
-set_target_properties(resman PROPERTIES
-        COMPILE_FLAGS "-std=c++0x -Wno-return-type")
+set_target_properties(resman PROPERTIES COMPILE_FLAGS "-Wno-return-type")

--- a/plugins/statsd/CMakeLists.txt
+++ b/plugins/statsd/CMakeLists.txt
@@ -3,6 +3,6 @@ include_directories(.)
 add_module(statsd NWNXStatsd plugin-statsd statsd_client)
 
 set_target_properties(statsd PROPERTIES
-        COMPILE_FLAGS "-std=c++0x -Wno-deprecated -Wno-return-type")
+        COMPILE_FLAGS "-Wno-deprecated -Wno-return-type")
 
 target_link_libraries(statsd rt)


### PR DESCRIPTION
This adds a check to pick either c++0x or c++11 depending on compiler
support. It will error out when neither standard flag is supported.

Open for discussion. :)