### PR TITLE
EVENT_CORE_CONSOLE_INPUT to allow plugins handle input on the console

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,8 @@ add_library(nwnx2 SHARED nwnx2lib NWNXBase modules lists gline
 	api/nwnsyms.S api/all
 
     core/core
+    core/events/Console
+    core/events/Console_Builtins
     core/events/Mainloop
     core/events/Module
     core/events/RunScript

--- a/NWNXBase.cpp
+++ b/NWNXBase.cpp
@@ -116,6 +116,11 @@ int CNWNXBase::SetDebugLevel(int level)
     return temp;
 }
 
+int CNWNXBase::GetDebugLevel()
+{
+    return debuglevel;
+}
+
 void CNWNXBase::BaseConf()
 {
 

--- a/NWNXBase.h
+++ b/NWNXBase.h
@@ -99,6 +99,8 @@ public:
     //  level	: the desired level
     int SetDebugLevel(int level);
 
+    int GetDebugLevel();
+
     ///////////////////////////////////////////////////////////////////////////
     // Function: BaseConf ();
     // Description:

--- a/core/core.cpp
+++ b/core/core.cpp
@@ -2,6 +2,8 @@
 
 PLUGINLINK *pluginLink;
 
+void Core_Console_Init();
+void Core_Console_Builtins_Init();
 void Core_Mainloop_Init();
 void Core_Module_Init();
 void Core_RunScript_Init();
@@ -11,6 +13,8 @@ void Core_Init(PLUGINLINK *link)
 {
     pluginLink = link;
 
+    Core_Console_Init();
+    Core_Console_Builtins_Init();
     Core_Mainloop_Init();
     Core_Module_Init();
     Core_RunScript_Init();

--- a/core/events/Console.cpp
+++ b/core/events/Console.cpp
@@ -1,0 +1,63 @@
+#include "../core.h"
+
+#include "NWNXApi.h"
+#include "NWNXBase.h"
+
+#include <map>
+#include <string>
+
+static HANDLE hConsoleInput;
+
+static void (*ProcessKeyboardInput)();
+static void ProcessKeyboardInput_Hook()
+{
+    CExoCriticalSection *mtx = (CExoCriticalSection*) 0x083CF428;
+    const char *g_szCommand = (const char*) 0x083CF440;
+    bool *g_ProcessCommand = (bool*) 0x0832F204;
+
+    bool parent_was_called = false;
+    bool call_parent = true;
+
+    mtx->EnterCriticalSection();
+
+    char *g_szCommand_dup = strdup(g_szCommand);
+
+    if (*g_ProcessCommand) {
+        const char *command = strtok(g_szCommand_dup, " ");
+        const char *rest = strtok(NULL, "");
+
+        // Help is a bit of a special case: We need to call the parent handler
+        // FIRST (to print the builtin commands), then our own.
+        // For all other cases, we want to check our own first and only then
+        // call parent.
+        if (!strcmp("help", command)) {
+            mtx->LeaveCriticalSection();
+            ProcessKeyboardInput();
+            parent_was_called = true;
+            mtx->EnterCriticalSection();
+            printf("\nCommands provided by NWNX:\n\n");
+        }
+
+        CoreConsoleInputEvent ev = { command, rest ? rest : "", true };
+        NotifyEventHooksNotAbortable(hConsoleInput, (uintptr_t) &ev);
+        call_parent = ev.pass;
+
+        if (!call_parent)
+            *g_ProcessCommand = 0;
+    }
+
+    free(g_szCommand_dup);
+
+    mtx->LeaveCriticalSection();
+
+    if (!parent_was_called && call_parent)
+        ProcessKeyboardInput();
+}
+
+void Core_Console_Init()
+{
+    hConsoleInput = CreateHookableEvent(EVENT_CORE_CONSOLE_INPUT);
+
+    NX_HOOK(ProcessKeyboardInput, 0x0804D328,
+            ProcessKeyboardInput_Hook, 5);
+}

--- a/core/events/Console_Builtins.cpp
+++ b/core/events/Console_Builtins.cpp
@@ -1,0 +1,57 @@
+#include "../core.h"
+
+#include "NWNXApi.h"
+#include "NWNXBase.h"
+
+extern const std::map<std::string, CNWNXBase*> & GetLoadedLibraries();
+extern const int GetCoreDebugLevel();
+extern void SetCoreDebugLevel(int level);
+
+static int DebugLevel(uintptr_t p)
+{
+    auto ev = (CoreConsoleInputEvent*) p;
+
+    if (!strcmp("help", ev->command)) {
+        printf("debuglevel [level] [plugin]\n");
+        printf("\tPrint or set NWNX debug level, either global or per plugin.\n");
+    }
+
+    else if (!strcmp("debuglevel", ev->command)) {
+        char *arg = strdup(ev->arguments);
+        char *level = strtok(arg, " ");
+
+        if (!level) {
+            printf("Debuglevels:\n (Core): %d\n", GetCoreDebugLevel());
+            for (auto &it : GetLoadedLibraries())
+                printf(" %s: %d\n", it.first.c_str(), it.second->GetDebugLevel());
+
+        } else {
+            char *plugin = strtok(NULL, "");
+            int lv = atoi(level);
+            if (lv < 0) lv = 0;
+
+            if (!plugin) {
+                SetCoreDebugLevel(lv);
+                printf("Core debug level changed to %d\n", lv);
+
+            } else {
+                auto it = GetLoadedLibraries().find(plugin);
+                if (it != GetLoadedLibraries().end()) {
+
+                    it->second->SetDebugLevel(lv);
+                    printf("%s debug level changed to %d\n", plugin, lv);
+
+                } else
+                    printf("Plugin %s not loaded\n", plugin);
+            }
+        }
+
+        free(arg);
+        ev->pass = false;
+    }
+}
+
+void Core_Console_Builtins_Init()
+{
+    HookEvent(EVENT_CORE_CONSOLE_INPUT, DebugLevel);
+}

--- a/core/pluginlink.h
+++ b/core/pluginlink.h
@@ -159,3 +159,29 @@ struct ObjectCreatedEvent {
 struct ObjectDestroyedEvent {
     const void *object;
 };
+
+/**
+ * Event: EVENT_CORE_CONSOLE_INPUT
+ * Param: CoreConsoleInputEvent
+ * Abortable: No
+ * Initializer: Always
+ *
+ * Called for input on the server console.
+ * This event runs in the nwserver main loop.
+ *
+ * Set param->pass to false to stop nwserver from handling the command.
+ *
+ * Hint: If you want to output help for your command, just printf it to stdout
+ * in the following format when command matches "help":
+ *
+ *     printf("wobbit <count>");
+ *     printf("\tSpawn <count> wobbits.");
+ *
+ * Your text will be added to the bottom of the output.
+ */
+#define EVENT_CORE_CONSOLE_INPUT "Core/Console/Input"
+struct CoreConsoleInputEvent {
+    const char *command;
+    const char *arguments;
+    bool pass;
+};

--- a/nwnx2lib.cpp
+++ b/nwnx2lib.cpp
@@ -76,6 +76,21 @@ static int nwnxinitdisabled = 0;
 // hashtable (ok, ok, a red-black tree)
 static map<string, CNWNXBase*> Libraries;
 
+const map<string, CNWNXBase*> & GetLoadedLibraries()
+{
+    return Libraries;
+}
+
+const int GetCoreDebugLevel()
+{
+    return debuglevel;
+}
+
+void SetCoreDebugLevel(int level)
+{
+    debuglevel = level;
+}
+
 static unsigned char jmp_code[] = "\x68\x60\x70\x80\x90"	/* push dword 0x90807060 */
                                   "\xc3\x90\x90";		/* ret , nop , nop       */
 static unsigned char ret_code_ss[0x20] asm("ret_code_ss");


### PR DESCRIPTION
This also handles "help" transparently so plugins can add their own
help text with minimum fuss.

Some sample commands are included.

Had to hack some global functions in to read the plugin list and
global debuglevel.

--

The helpers I had to hack in aren't all that smooth I guess. Especially not the one that adds to CNWNXBase.

Anyways, please review/discuss!