### PR TITLE
NX_HOOK_CALL: helper+macro to hook mid-function calls

### DIFF
--- a/core/events/Module.cpp
+++ b/core/events/Module.cpp
@@ -33,17 +33,11 @@ static short CServerExoApp__GetServerMode(CServerExoApp *s)
     return ret;
 }
 
-static inline void HookCall(DWORD src_addr, DWORD to_addr)
-{
-    nx_hook_enable_write((void*) src_addr, 5);
-    *(DWORD *)(src_addr + 1) = to_addr - (src_addr + 5);
-}
-
 void Core_Module_Init()
 {
     hModuleLoading = CreateHookableEvent(EVENT_CORE_MODULE_LOADING);
     hModuleLoaded = CreateHookableEvent(EVENT_CORE_MODULE_LOADED);
 
-    HookCall(0x0804e712, (DWORD) CServerExoApp__LoadModule);
-    HookCall(0x0804e77a, (DWORD) CServerExoApp__GetServerMode);
+    NX_HOOK_CALL(0x0804e712, CServerExoApp__LoadModule);
+    NX_HOOK_CALL(0x0804e77a, CServerExoApp__GetServerMode);
 }

--- a/include/nx_hook.h
+++ b/include/nx_hook.h
@@ -35,6 +35,7 @@ int nx_hook_enable_exec(const void *addr, size_t len);
 int nx_hook_enable_write(const void *addr, size_t len);
 
 void *nx_hook_function(void *addr, void *func, size_t len, uint32_t flags);
+void nx_hook_function_call(void *addr, void *func);
 
 void nwn_hook_init(void);
 
@@ -55,6 +56,14 @@ void nwn_hook_init(void);
  */
 #define NX_HOOK(orig, addr, hook, bytes) \
     *(void**)&orig = nx_hook_function((void*)addr, (void*)hook, bytes, NX_HOOK_DIRECT | NX_HOOK_RETCODE)
+
+/**
+ * Macro: NX_HOOK_CALL
+ *
+ * Helper macro to hook mid-function calls without having to apply user casts.
+ */
+#define NX_HOOK_CALL(addr,hook) \
+    nx_hook_function_call((void*) addr, (void*) hook)
 
 #endif /* _NX_HOOK_H_ */
 

--- a/lib/nx_hook.c
+++ b/lib/nx_hook.c
@@ -107,4 +107,10 @@ void *nx_hook_function(void *addr, void *func, size_t len, uint32_t flags)
     return trampoline;
 }
 
+void nx_hook_function_call(void *addr, void *func)
+{
+    nx_hook_enable_write((void*) addr, 5);
+    *(uint32_t *)(addr + 1) = func - (addr + 5);
+}
+
 /* vim: set sw=4: */


### PR DESCRIPTION
This adds a helper function and macro to hook mid-function calls by
address and updates the usecase in core/Module.cpp.

Not sure what else to say - it's what I use all the time to grab calls
mid-function and redirect them to a local wrapper.

Basically what already happens in Module.cpp.