### PR TITLE
core/: ThreadUtils helpers for easier mainloop barrier syncing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,11 @@ add_library(nwnx2 SHARED nwnx2lib NWNXBase modules lists gline
     core/events/Module
     core/events/RunScript
     core/events/Object
+    core/ThreadUtil
 )
+
+# for core/ThreadUtil
+target_link_libraries(nwnx2 pthread)
 
 # Fake target to force recreating the compiled directory.
 add_custom_target(always_rebuild_compiled ALL

--- a/core/ThreadUtil.cpp
+++ b/core/ThreadUtil.cpp
@@ -1,0 +1,68 @@
+#include "ThreadUtil.h"
+
+#include <queue>
+#include <mutex>
+#include <atomic>
+#include <future>
+#include <thread>
+
+typedef std::packaged_task<void()> QueuedWork;
+static std::queue<QueuedWork> vm_run_queue;
+
+static std::mutex vm_run_queue_mutex;
+
+std::future<void> Mainloop::Next(std::function<void()> f)
+{
+    std::packaged_task<void()> task(f);
+    auto fu = task.get_future();
+
+    {
+        std::lock_guard<std::mutex> guard(vm_run_queue_mutex);
+        vm_run_queue.push(std::move(task));
+    }
+
+    return fu;
+}
+
+static std::atomic_bool mainloopThreadResolved(false);
+static std::thread::id mainloopThreadId;
+
+void Mainloop::Now(std::function<void()> f)
+{
+    if (!mainloopThreadResolved.load()) {
+        // If you see this, don't run Now() inside plugin initializers. :)
+        fprintf(stderr,
+                "ERROR:\n"
+                "ThreadUtil::Now() before game mainloop starts will deadlock.\n"
+                "This is a problem with one of the plugins that uses Now()\n"
+                "while no module is up yet.\n");
+        abort();
+    }
+
+    if (mainloopThreadId == std::this_thread::get_id())
+        f();
+
+    else
+        Next(f).wait();
+}
+
+void ThreadUtil_Mainloop_After()
+{
+    if (!mainloopThreadResolved.load()) {
+        mainloopThreadId = std::this_thread::get_id();
+        mainloopThreadResolved = true;
+    }
+
+    std::queue<QueuedWork> vm_this_queue;
+
+    {
+        std::lock_guard<std::mutex> guard(vm_run_queue_mutex);
+        std::swap(vm_this_queue, vm_run_queue);
+    }
+
+    while (!vm_this_queue.empty()) {
+        auto& f = vm_this_queue.front();
+        f();
+        vm_this_queue.pop();
+    }
+}

--- a/core/ThreadUtil.h
+++ b/core/ThreadUtil.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#define HAVE_THREADUTIL
+
+#include <future>
+
+class Mainloop
+{
+public:
+    /**
+    * A helper to run code inside the gameserver mainloop.
+    *
+    * Will return a future that you can wait on if you need to interleave
+    * with the mainloop. You NEED to do this if you depend on return values
+    * captured in the function.
+    *
+    * Please note that you will deadlock the server when waiting on nested
+    * futures. If you wish to run code immediately, it's better to use
+    * Now() instead of Next().wait(), which guarantees not to deadlock even
+    * when nesting calls.
+    *
+    * Keep in mind that a running main loop is no guarantee that a module is
+    * up and game state accessible.
+    *
+    * Example:
+    *     auto f = Mainloop::Next([&] { printf("I'm in the main loop\n"); });
+    *     printf("I'm possibly running before the above.\n");
+    *     f.wait();
+    *     printf("I'm guaranteed to run after f is done!\n");
+    */
+    static std::future<void> Next(std::function<void()> f);
+
+    /**
+     * Semantically an alias to Next(f).wait(), but will yield immediately
+     * if already inside another scheduled function.
+     *
+     * Deadlock-free.
+     *
+     * Example:
+     *     Mainloop::Now([&] { printf("I'm in the main loop\n"); });
+     *     printf("I'm guaranteed to run AFTER the above.\n");
+     */
+    static void Now(std::function<void()> f);
+};

--- a/core/core.h
+++ b/core/core.h
@@ -2,5 +2,6 @@
 
 #include "newpluginapi.h"
 #include "pluginlink.h"
+#include "ThreadUtil.h"
 
 void Core_Init(PLUGINLINK *link);

--- a/core/events/Mainloop.cpp
+++ b/core/events/Mainloop.cpp
@@ -6,39 +6,41 @@ static HANDLE hMainLoopInnerBefore, hMainLoopInnerAfter;
 
 static int (*CServerExoApp__MainLoopInner)(void *pServer);
 
+void ThreadUtil_Mainloop_After();
+
 static int Hook_MainLoopInner(void *pServer)
 {
-	NotifyEventHooksNotAbortable(hMainLoopInnerBefore, 0);
+    NotifyEventHooksNotAbortable(hMainLoopInnerBefore, 0);
 
-	int ret = CServerExoApp__MainLoopInner(pServer);
+    int ret = CServerExoApp__MainLoopInner(pServer);
 
-	NotifyEventHooksNotAbortable(hMainLoopInnerAfter, 0);
+    ThreadUtil_Mainloop_After();
 
-	return ret;
+    NotifyEventHooksNotAbortable(hMainLoopInnerAfter, 0);
+
+    return ret;
 }
 
 static bool hooked = false;
 
 static int HookFunctions(uintptr_t p)
 {
-	if (hooked)
-		return true;
+    if (hooked)
+        return true;
 
-	nx_log(NX_LOG_INFO, 0, "core: Hooking CServerExoApp__MainLoopInner.");
-	NX_HOOK(CServerExoApp__MainLoopInner, 0x080B2050, Hook_MainLoopInner, 9);
+    nx_log(NX_LOG_INFO, 0, "core: Hooking CServerExoApp__MainLoopInner.");
+    NX_HOOK(CServerExoApp__MainLoopInner, 0x080B2050, Hook_MainLoopInner, 9);
 
-	hooked = true;
+    hooked = true;
 
-	return true;
+    return true;
 }
 
 void Core_Mainloop_Init()
 {
-	hMainLoopInnerBefore = CreateHookableEvent(EVENT_CORE_MAINLOOP_BEFORE);
-	hMainLoopInnerAfter = CreateHookableEvent(EVENT_CORE_MAINLOOP_AFTER);
+    hMainLoopInnerBefore = CreateHookableEvent(EVENT_CORE_MAINLOOP_BEFORE);
+    hMainLoopInnerAfter = CreateHookableEvent(EVENT_CORE_MAINLOOP_AFTER);
 
-	if (hMainLoopInnerBefore && hMainLoopInnerAfter) {
-		SetHookInitializer(hMainLoopInnerBefore, HookFunctions);
-		SetHookInitializer(hMainLoopInnerAfter, HookFunctions);
-	}
+    /* Always hook this due to ThreadUtils needing it. */
+    HookFunctions(0);
 }


### PR DESCRIPTION
Adds a C++ template that allows shunting code to be run in the NWN mainloop.

This is neccessary for multithreaded plugins (like network listeners, pubsub
systems, and so on).

--

**Please review and comment before merging.**