### PR TITLE
pluginlink: hooking and calling helpers that exit(1) on failure

### DIFF
--- a/modules.h
+++ b/modules.h
@@ -100,8 +100,8 @@ int SetHookInitializer(HANDLE hEvent, NWNXHOOK pfnInitialize);
  * HookEvent
  *
  * Adds a new hook to the chain 'name', to be called when the hook owner calls
- * NotifyEventHooks(). Returns NULL if name is not a valid event or a handle
- * referring to the hook otherwise.
+ * NotifyEventHooks(). Will abort() with a nice backtrace if the given hook
+ * name is not provided by anything.
  *
  * The type of parameter is defined by the creator of the event when
  * NotifyEventHooks() is called.
@@ -115,6 +115,14 @@ int SetHookInitializer(HANDLE hEvent, NWNXHOOK pfnInitialize);
  * NotifyEventHooksNotAbortable().
  */
 HANDLE HookEvent(const char *name, NWNXHOOK hookProc);
+
+/**
+ * HookEventOptionally
+ *
+ * The same as HookEvent, except that it will return NULL instead of abort()ing
+ * on failure.
+ */
+HANDLE HookEventOptionally(const char *name, NWNXHOOK hookProc);
 
 /**
  * UnhookEvent

--- a/newpluginapi.h
+++ b/newpluginapi.h
@@ -3,6 +3,8 @@
 #include "typedef.h"
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 #define PLUGIN_MAKE_VERSION(a,b,c,d) (((((DWORD)(a))&0xFF)<<24)|((((DWORD)(b))&0xFF)<<16)|((((DWORD)(c))&0xFF)<<8)|(((DWORD)(d))&0xFF))
 
@@ -42,6 +44,7 @@ typedef struct {
     int (*SetHookDefaultForHookableEvent)(HANDLE, NWNXHOOK);  // v0.3.4 (2004/09/15)
     const char* (*GetCurrentEventName)();
     int (*SetHookInitializer)(HANDLE hEvent, NWNXHOOK pfnIntialize);
+    HANDLE(*HookEventOptionally)(const char *, NWNXHOOK);
 } PLUGINLINK;
 
 #ifndef MODULES_H_
@@ -54,6 +57,7 @@ extern PLUGINLINK *pluginLink;
 #define NotifyEventHooksNotAbortable(a,b)    pluginLink->NotifyEventHooksNotAbortable(a,b)
 #define HookEventMessage(a,b,c)              pluginLink->HookEventMessage(a,b,c)
 #define HookEvent(a,b)                       pluginLink->HookEvent(a,b)
+#define HookEventOptionally(a,b)             pluginLink->HookEventOptionally(a,b)
 #define UnhookEvent(a)                       pluginLink->UnhookEvent(a)
 #define CreateServiceFunction(a,b)           pluginLink->CreateServiceFunction(a,b)
 #define CreateTransientServiceFunction(a,b)  pluginLink->CreateTransientServiceFunction(a,b)
@@ -62,7 +66,8 @@ extern PLUGINLINK *pluginLink;
 #define ServiceExists(a)                     pluginLink->ServiceExists(a)
 #define SetHookDefaultForHookableEvent(a,b)  pluginLink->SetHookDefaultForHookableEvent(a,b)
 #define GetCurrentEventName()                pluginLink->GetCurrentEventName()
-#define SetHookInitializer(a,b)               pluginLink->SetHookInitializer(a,b)
+#define SetHookInitializer(a,b)              pluginLink->SetHookInitializer(a,b)
+
 #endif
 #endif
 

--- a/nwnx2lib.cpp
+++ b/nwnx2lib.cpp
@@ -679,6 +679,7 @@ void LoadCoreModule()
     pluginCoreLink.SetHookDefaultForHookableEvent = SetHookDefaultForHookableEvent;
     pluginCoreLink.GetCurrentEventName = GetCurrentEventName;
     pluginCoreLink.SetHookInitializer = SetHookInitializer;
+    pluginCoreLink.HookEventOptionally = HookEventOptionally;
     //pluginCoreLink.NotifyEventHooksDirect=CallHookSubscribers;
 
     hPluginsLoadedEvent = CreateHookableEvent(EVENT_CORE_PLUGINSLOADED);

--- a/plugins/jvm/NWNXJVM.cpp
+++ b/plugins/jvm/NWNXJVM.cpp
@@ -83,10 +83,10 @@ CNWNXJVM::CNWNXJVM()
 
 int systemStartup(uintptr_t p)
 {
-    HANDLE handleSCO = HookEvent(EVENT_ODBC_RCO, ReadSCO);
-    HANDLE handleRCO = HookEvent(EVENT_ODBC_SCO, WriteSCO);
-    HANDLE handleResManExists = HookEvent(EVENT_RESMAN_EXISTS, ResManExists);
-    HANDLE handleResManDemand = HookEvent(EVENT_RESMAN_DEMAND, ResManDemand);
+    HANDLE handleSCO = HookEventOptionally(EVENT_ODBC_RCO, ReadSCO);
+    HANDLE handleRCO = HookEventOptionally(EVENT_ODBC_SCO, WriteSCO);
+    HANDLE handleResManExists = HookEventOptionally(EVENT_RESMAN_EXISTS, ResManExists);
+    HANDLE handleResManDemand = HookEventOptionally(EVENT_RESMAN_DEMAND, ResManDemand);
     if (!handleSCO || !handleRCO || !handleResManExists || !handleResManDemand)
         printf("Cannot hook SCORCO or ResMan events!\n");
 

--- a/plugins/resman/DirectoryHandler.cpp
+++ b/plugins/resman/DirectoryHandler.cpp
@@ -80,17 +80,12 @@ static int HandleDemandResourceEvent(uintptr_t p)
 bool RegisterDirectoryHandlers()
 {
     bool result = true;
-    HANDLE handleResourceExists = HookEvent(EVENT_RESMAN_EXISTS, HandleResourceExistsEvent);
-    if (!handleResourceExists) {
-        resman.Log(0, "Cannot hook EVENT_RESMAN_EXISTS!\n");
-        result = false;
-    }
 
-    HANDLE handleDemandResource = HookEvent(EVENT_RESMAN_DEMAND, HandleDemandResourceEvent);
-    if (!handleDemandResource) {
-        resman.Log(0, "Cannot hook EVENT_RESMAN_DEMAND!\n");
-        result = false;
-    }
+    HANDLE handleResourceExists = HookEvent(EVENT_RESMAN_EXISTS,
+        HandleResourceExistsEvent);
+
+    HANDLE handleDemandResource = HookEvent(EVENT_RESMAN_DEMAND,
+        HandleDemandResourceEvent);
 
     return result;
 }


### PR DESCRIPTION
This is mostly for lazy plugin authors (like me) that want to hook
events or call services and just fail when they don't exist, because
the plugin would not work otherwise.

Best used in OnPluginsLoaded or similar - fail early and hard, like you
read about.

--

What do you think?

(In any case don't merge yet, if this is desirable I'll add optional/better error messages and warnings to the default macros too).