### PR TITLE
nwnx_funcsext bugfixes

### DIFF
--- a/plugins/funcsext/funcsext_trgclk.nss
+++ b/plugins/funcsext/funcsext_trgclk.nss
@@ -1,7 +1,9 @@
-void main() {
+void main()
+{
     object oTarget = GetLocalObject(OBJECT_SELF, "FUNCSEXT_TRANSITION_TARGET");
-    if(GetIsObjectValid(oTarget)) {
-        SetAreaTransitionBMP(AREA_TRANSITION_RANDOM);
-        AssignCommand(GetClickingObject(), JumpToObject(oTarget));
-    }
+	if (GetIsObjectValid(oTarget)) {
+		object oC = GetClickingObject();
+		if (GetIsObjectValid(oC))
+			AssignCommand(oC, JumpToObject(oTarget));
+	}
 }

--- a/plugins/funcsext/nwnx_funcsext.nss
+++ b/plugins/funcsext/nwnx_funcsext.nss
@@ -1,88 +1,106 @@
+/****************************************************************************
+
+	nwnx_funcsext - extended functions for nwnx
+
+	NB - experimental
+
+/****************************************************************************/
+
+//////////////////////////////////////////////////////////////////////////////
+//                                                                          //
+//                                 CONSTANTS                                //
+//                                                                          //
+//////////////////////////////////////////////////////////////////////////////
+
+//
+// constants for SetScript()
+//
 const int
-    CREATURE_SCRIPT_HEARTBEAT       = 0,
-    CREATURE_SCRIPT_PERCEPTION      = 1,
-    CREATURE_SCRIPT_SPELLCAST_AT    = 2,
-    CREATURE_SCRIPT_ATTACKED        = 3,
-    CREATURE_SCRIPT_DAMAGED         = 4,
-    CREATURE_SCRIPT_DISTURBED       = 5,
-    CREATURE_SCRIPT_COMBAT_ROUND    = 6,
-    CREATURE_SCRIPT_CONVERSATION    = 7,
-    CREATURE_SCRIPT_SPAWN           = 8,
-    CREATURE_SCRIPT_RESTED          = 9,
-    CREATURE_SCRIPT_DEATH           = 10,
-    CREATURE_SCRIPT_USER_DEFINED    = 11,
-    CREATURE_SCRIPT_BLOCKED         = 12,
+    NWNX_SCRIPT_CREATURE_HEARTBEAT       = 0,
+    NWNX_SCRIPT_CREATURE_PERCEPTION      = 1,
+    NWNX_SCRIPT_CREATURE_SPELLCAST_AT    = 2,
+    NWNX_SCRIPT_CREATURE_ATTACKED        = 3,
+    NWNX_SCRIPT_CREATURE_DAMAGED         = 4,
+    NWNX_SCRIPT_CREATURE_DISTURBED       = 5,
+    NWNX_SCRIPT_CREATURE_COMBAT_ROUND    = 6,
+    NWNX_SCRIPT_CREATURE_CONVERSATION    = 7,
+    NWNX_SCRIPT_CREATURE_SPAWN           = 8,
+    NWNX_SCRIPT_CREATURE_RESTED          = 9,
+    NWNX_SCRIPT_CREATURE_DEATH           = 10,
+    NWNX_SCRIPT_CREATURE_USER_DEFINED    = 11,
+    NWNX_SCRIPT_CREATURE_BLOCKED         = 12,
 
-    PLACEABLE_SCRIPT_CLOSE          = 0,
-    PLACEABLE_SCRIPT_DAMAGE         = 1,
-    PLACEABLE_SCRIPT_DEATH          = 2,
-    PLACEABLE_SCRIPT_HEARTBEAT      = 4,
-    PLACEABLE_SCRIPT_DISTURBED      = 5,
-    PLACEABLE_SCRIPT_LOCK           = 6,
-    PLACEABLE_SCRIPT_ATTACKED       = 7,
-    PLACEABLE_SCRIPT_OPEN           = 8,
-    PLACEABLE_SCRIPT_SPELLCAST_AT   = 9,
-    PLACEABLE_SCRIPT_UNLOCK         = 11,
-    PLACEABLE_SCRIPT_USED           = 12,
-    PLACEABLE_SCRIPT_USER_DEFINED   = 13,
-    PLACEABLE_SCRIPT_CLICK          = 15,
+    NWNX_SCRIPT_PLACEABLE_CLOSE          = 0,
+    NWNX_SCRIPT_PLACEABLE_DAMAGE         = 1,
+    NWNX_SCRIPT_PLACEABLE_DEATH          = 2,
+    NWNX_SCRIPT_PLACEABLE_HEARTBEAT      = 4,
+    NWNX_SCRIPT_PLACEABLE_DISTURBED      = 5,
+    NWNX_SCRIPT_PLACEABLE_LOCK           = 6,
+    NWNX_SCRIPT_PLACEABLE_ATTACKED       = 7,
+    NWNX_SCRIPT_PLACEABLE_OPEN           = 8,
+    NWNX_SCRIPT_PLACEABLE_SPELLCAST_AT   = 9,
+    NWNX_SCRIPT_PLACEABLE_UNLOCK         = 11,
+    NWNX_SCRIPT_PLACEABLE_USED           = 12,
+    NWNX_SCRIPT_PLACEABLE_USER_DEFINED   = 13,
+    NWNX_SCRIPT_PLACEABLE_CLICK          = 15,
 
-    MODULE_SCRIPT_HEARTBEAT         = 0,
-    MODULE_SCRIPT_USER_DEFINED      = 1,
-    MODULE_SCRIPT_LOAD              = 2,
-    MODULE_SCRIPT_CLIENT_ENTER      = 4,
-    MODULE_SCRIPT_CLIENT_LEAVE      = 5,
-    MODULE_SCRIPT_ACTIVATE_ITEM     = 6,
-    MODULE_SCRIPT_ACQURATE_ITEM     = 7,
-    MODULE_SCRIPT_UNACQURATE_ITEM   = 8,
-    MODULE_SCRIPT_PLAYER_DEATH      = 9,
-    MODULE_SCRIPT_PLAYER_DYING      = 10,
-    MODULE_SCRIPT_PLAYER_RESPAWN    = 11,
-    MODULE_SCRIPT_PLAYER_REST       = 12,
-    MODULE_SCRIPT_PLAYER_LEVELUP    = 13,
-    MODULE_SCRIPT_CURSCENE_ABORT    = 14,
-    MODULE_SCRIPT_EQUIP_ITEM        = 15,
-    MODULE_SCRIPT_UNEQUIP_ITEM      = 16,
-    MODULE_SCRIPT_PLAYER_CHAT       = 17,
+    NWNX_SCRIPT_MODULE_HEARTBEAT         = 0,
+    NWNX_SCRIPT_MODULE_USER_DEFINED      = 1,
+    NWNX_SCRIPT_MODULE_LOAD              = 2,
+    NWNX_SCRIPT_MODULE_CLIENT_ENTER      = 4,
+    NWNX_SCRIPT_MODULE_CLIENT_LEAVE      = 5,
+    NWNX_SCRIPT_MODULE_ACTIVATE_ITEM     = 6,
+    NWNX_SCRIPT_MODULE_ACQURATE_ITEM     = 7,
+    NWNX_SCRIPT_MODULE_UNACQURATE_ITEM   = 8,
+    NWNX_SCRIPT_MODULE_PLAYER_DEATH      = 9,
+    NWNX_SCRIPT_MODULE_PLAYER_DYING      = 10,
+    NWNX_SCRIPT_MODULE_PLAYER_RESPAWN    = 11,
+    NWNX_SCRIPT_MODULE_PLAYER_REST       = 12,
+    NWNX_SCRIPT_MODULE_PLAYER_LEVELUP    = 13,
+    NWNX_SCRIPT_MODULE_CURSCENE_ABORT    = 14,
+    NWNX_SCRIPT_MODULE_EQUIP_ITEM        = 15,
+    NWNX_SCRIPT_MODULE_UNEQUIP_ITEM      = 16,
+    NWNX_SCRIPT_MODULE_PLAYER_CHAT       = 17,
 
-    AREA_SCRIPT_HEARTBEAT           = 0,
-    AREA_SCRIPT_USER_DEFINED        = 1,
-    AREA_SCRIPT_ENTER               = 2,
-    AREA_SCRIPT_EXIT                = 3,
+    NWNX_SCRIPT_AREA_HEARTBEAT           = 0,
+    NWNX_SCRIPT_AREA_USER_DEFINED        = 1,
+    NWNX_SCRIPT_AREA_ENTER               = 2,
+    NWNX_SCRIPT_AREA_EXIT                = 3,
 
-    DOOR_SCRIPT_OPEN                = 0,
-    DOOR_SCRIPT_CLOSE               = 1,
-    DOOR_SCRIPT_DAMAGED             = 2,
-    DOOR_SCRIPT_DEATH               = 3,
-    DOOR_SCRIPT_HEARTBEAT           = 5,
-    DOOR_SCRIPT_LOCKED              = 6,
-    DOOR_SCRIPT_ATTACKED            = 7,
-    DOOR_SCRIPT_SPELCAST_AT         = 8,
-    DOOR_SCRIPT_UNLOCKED            = 10,
-    DOOR_SCRIPT_USER_DEFINED        = 11,
-    DOOR_SCRIPT_TRANSITION_CLICK    = 12,
-    DOOR_SCRIPT_FAIL_TO_OPEN        = 14,
+    NWNX_SCRIPT_DOOR_OPEN                = 0,
+    NWNX_SCRIPT_DOOR_CLOSE               = 1,
+    NWNX_SCRIPT_DOOR_DAMAGED             = 2,
+    NWNX_SCRIPT_DOOR_DEATH               = 3,
+    NWNX_SCRIPT_DOOR_HEARTBEAT           = 5,
+    NWNX_SCRIPT_DOOR_LOCKED              = 6,
+    NWNX_SCRIPT_DOOR_ATTACKED            = 7,
+    NWNX_SCRIPT_DOOR_SPELCAST_AT         = 8,
+    NWNX_SCRIPT_DOOR_UNLOCKED            = 10,
+    NWNX_SCRIPT_DOOR_USER_DEFINED        = 11,
+    NWNX_SCRIPT_DOOR_TRANSITION_CLICK    = 12,
+    NWNX_SCRIPT_DOOR_FAIL_TO_OPEN        = 14,
 
-    STORE_SCIRPT_OPEN               = 0,
-    STORE_SCRIPT_CLOSE              = 1,
+    NWNX_SCRIPT_STORE_OPEN               = 0,
+    NWNX_SCRIPT_STORE_CLOSE              = 1,
 
-    TRIGGER_SCRIPT_HEARTBEAT        = 0,
-    TRIGGER_SCRIPT_ENTER            = 1,
-    TRIGGER_SCRIPT_EXIT             = 2,
-    TRIGGER_SCRIPT_USER_DEFINED     = 3,
-    TRIGGER_SCRIPT_TRANSITION_CLICK = 6,
+    NWNX_SCRIPT_TRIGGER_HEARTBEAT        = 0,
+    NWNX_SCRIPT_TRIGGER_ENTER            = 1,
+    NWNX_SCRIPT_TRIGGER_EXIT             = 2,
+    NWNX_SCRIPT_TRIGGER_USER_DEFINED     = 3,
+    NWNX_SCRIPT_TRIGGER_TRANSITION_CLICK = 6,
 
-    ENCOUNTER_SCRIPT_ENTER          = 0,
-    ENCOUNTER_SCRIPT_EXIT           = 1,
-    ENCOUNTER_SCRIPT_HEARTBEAT      = 2,
-    ENCOUNTER_SCRIPT_EXHAUSTED      = 3,
-    ENCOUNTER_SCRIPT_USER_DEFINED   = 4,
+    NWNX_SCRIPT_ENCOUNTER_ENTER          = 0,
+    NWNX_SCRIPT_ENCOUNTER_EXIT           = 1,
+    NWNX_SCRIPT_ENCOUNTER_HEARTBEAT      = 2,
+    NWNX_SCRIPT_ENCOUNTER_EXHAUSTED      = 3,
+    NWNX_SCRIPT_ENCOUNTER_USER_DEFINED   = 4;
 
-
+const int
     AREA_TRANSITION_LINK_NONE       = 0,
     AREA_TRANSITION_LINK_DOOR       = 1,
-    AREA_TRANSITION_LINK_WAYPOINT   = 2,
+    AREA_TRANSITION_LINK_WAYPOINT   = 2;
 
+const int
     SURFACE_MATERIAL_DIRT           = 1,
     SURFACE_MATERIAL_OBSCURING      = 2,
     SURFACE_MATERIAL_GRASS          = 3,
@@ -107,19 +125,92 @@ const int
     SURFACE_MATERIAL_STONEBRIDGE    = 22,
     SURFACE_MATERIAL_TRIGGER        = 30;
 
+//
+// constants for GetAnimation()
+// these are the values actually returned by nwnx for the given animations
+
+const int NWNX_ANIMATION_LOOPING_PAUSE2                   = 52;
+const int NWNX_ANIMATION_LOOPING_LISTEN                   = 30;
+const int NWNX_ANIMATION_LOOPING_MEDITATE                 = 32;
+const int NWNX_ANIMATION_LOOPING_WORSHIP                  = 33;
+const int NWNX_ANIMATION_LOOPING_LOOK_FAR                 = 48;
+const int NWNX_ANIMATION_LOOPING_SIT_CHAIR                = 36;
+const int NWNX_ANIMATION_LOOPING_SIT_CROSS                = 47;
+const int NWNX_ANIMATION_LOOPING_TALK_NORMAL              = 38;
+const int NWNX_ANIMATION_LOOPING_TALK_PLEADING            = 39;
+const int NWNX_ANIMATION_LOOPING_TALK_FORCEFUL            = 40;
+const int NWNX_ANIMATION_LOOPING_TALK_LAUGHING            = 41;
+const int NWNX_ANIMATION_LOOPING_GET_LOW                  = 59;
+const int NWNX_ANIMATION_LOOPING_GET_MID                  = 60;
+const int NWNX_ANIMATION_LOOPING_PAUSE_TIRED              = 57;
+const int NWNX_ANIMATION_LOOPING_PAUSE_DRUNK              = 58;
+const int NWNX_ANIMATION_LOOPING_DEAD_FRONT               = 6;
+const int NWNX_ANIMATION_LOOPING_DEAD_BACK                = 8;
+const int NWNX_ANIMATION_LOOPING_CONJURE1                 = 15;
+const int NWNX_ANIMATION_LOOPING_CONJURE2                 = 16;
+const int NWNX_ANIMATION_LOOPING_SPASM                    = 93;
+const int NWNX_ANIMATION_LOOPING_CUSTOM1                  = 97;
+const int NWNX_ANIMATION_LOOPING_CUSTOM2                  = 98;
+const int NWNX_ANIMATION_LOOPING_CUSTOM3                  = 101;
+const int NWNX_ANIMATION_LOOPING_CUSTOM4                  = 102;
+const int NWNX_ANIMATION_LOOPING_CUSTOM5                  = 103;
+const int NWNX_ANIMATION_LOOPING_CUSTOM6                  = 104;
+const int NWNX_ANIMATION_LOOPING_CUSTOM7                  = 105;
+const int NWNX_ANIMATION_LOOPING_CUSTOM8                  = 106;
+const int NWNX_ANIMATION_LOOPING_CUSTOM9                  = 107;
+const int NWNX_ANIMATION_LOOPING_CUSTOM10                 = 108;
+const int NWNX_ANIMATION_LOOPING_CUSTOM11                 = 109;
+const int NWNX_ANIMATION_LOOPING_CUSTOM12                 = 110;
+const int NWNX_ANIMATION_LOOPING_CUSTOM13                 = 111;
+const int NWNX_ANIMATION_LOOPING_CUSTOM14                 = 112;
+const int NWNX_ANIMATION_LOOPING_CUSTOM15                 = 113;
+const int NWNX_ANIMATION_LOOPING_CUSTOM16                 = 114;
+const int NWNX_ANIMATION_LOOPING_CUSTOM17                 = 115;
+const int NWNX_ANIMATION_LOOPING_CUSTOM18                 = 116;
+const int NWNX_ANIMATION_LOOPING_CUSTOM19                 = 117;
+const int NWNX_ANIMATION_LOOPING_CUSTOM20                 = 118;
+const int NWNX_ANIMATION_MOUNT1                           = 119;
+const int NWNX_ANIMATION_DISMOUNT1                        = 120;
+
+
+//////////////////////////////////////////////////////////////////////////////
+//                                                                          //
+//                                PROTOTYPES                                //
+//                                                                          //
+//////////////////////////////////////////////////////////////////////////////
+
 // Sets target's event handler script
+//   object oTarget - the object whose event will be handled.
+//   int nScript - the event to handle. see the NWNX_SCRIPT_* constants.
+//   string sScript - name of script to call.
 void SetScript(object oTarget, int nScript, string sScript="");
 
-// Gets target's event handler script
+// Gets target's event handler script as set by SetScript()
 string GetScript(object oTarget, int nScript);
 
-// Creates area transition
-object CreateAreaTransitionOnLocation(location lLocation, int nLinkType=AREA_TRANSITION_LINK_NONE, string sTargetTag="", float fSize=2.0f,  string sTag="");
+// Create a square-shaped 'pseudo-transition' centred at the provided location
+//   location lLocation - where to place the transition
+//   int nLinkType - type of transition - AREA_TRANSITION_LINK_DOOR,
+//     AREA_TRANSITION_LINK_WAYPOINT or AREA_TRANSITION_LINK_NONE (default)
+//   string sTargetTag - tag of the object the transition should point to
+//     sTargTag is required if nLinkType <> AREA_TRANSITION_LINK_NONE
+//   float fSize - the radius of the transition. must be at least 1.0
+//   string sTag - the tag of the newly-created transition
+//   CAVEAT - the transition created by this function is not a standard transition
+//            and will always return OBJECT_INVALID for GetTransitionTarget() !
+object CreateAreaTransitionAtLocation(location lLocation, int nLinkType=AREA_TRANSITION_LINK_NONE, string sTargetTag="", float fSize=1.0f,  string sTag="");
+
+// Create a square-shaped trigger centred at the provided location
+//   location lLocation - where to place the transition
+//   float fSize - the width of the trigger
+//   string sTag - the newly-created trigger's tag
+object CreateGenericTriggerAtLocation(location lLocation, float fSize=2.0f, string sTag="");
 
 // Get surface material type from location
+// returns - integer value corresponding to one of the SURFACE_MATERIAL_* constants
 int GetSurface(location lLocation);
 
-// Get current animation of oTarget
+// Get the animation currently active on oTarget. see the ANIMATION_* constants.
 int GetAnimation(object oTarget);
 
 // Display timing bar for creature and run sScript after delay
@@ -143,10 +234,18 @@ void AreaVisualEffectForPC(object oPC, int nVFX, vector vPosition);
 // Change possession of oPC to oCreature
 void PossessCreature(object oPC, object oCreature);
 
+// unpossess creature formerly possessed with PossessCreature()
 void UnPossessCreature(object oPC, object oCreature);
 
-// Get is oCreature flat-footed
+// return a boolean int indicating whether or not oCreature is flat-footed
 int GetFlatFooted(object oCreature);
+
+
+//////////////////////////////////////////////////////////////////////////////
+//                                                                          //
+//                              IMPLEMENTATION                              //
+//                                                                          //
+//////////////////////////////////////////////////////////////////////////////
 
 void SetScript(object oTarget, int nScript, string sScript="") {
     SetLocalString(oTarget, "NWNX!FUNCSEXT!SETSCRIPT", IntToString(nScript)+":"+sScript+"          ");
@@ -160,7 +259,7 @@ string GetScript(object oTarget, int nScript) {
     return sRet;
 }
 
-object CreateGenericTriggerOnLocation(location lLocation, float fSize=2.0f,  string sTag="") {
+object CreateGenericTriggerAtLocation(location lLocation, float fSize=2.0f, string sTag="") {
     object oTrigger = CreateTrapAtLocation(1, lLocation, fSize, sTag);
     if(GetIsObjectValid(oTrigger)) {
         SetLocalString(oTrigger, "NWNX!FUNCSEXT!SETISGENERICTRIGGER", "          ");
@@ -169,33 +268,32 @@ object CreateGenericTriggerOnLocation(location lLocation, float fSize=2.0f,  str
     return oTrigger;
 }
 
-object CreateAreaTransitionOnLocation(location lLocation, int nLinkType=AREA_TRANSITION_LINK_NONE, string sTargetTag="", float fSize=2.0f,  string sTag="") {
+object CreateAreaTransitionAtLocation(location lLocation, int nLinkType=AREA_TRANSITION_LINK_NONE, string sTargetTag="", float fSize=2.0f,  string sTag="")
+{
+	object oTarget;
+
+	// first make sure the target exists and is of the correct type
+	if (nLinkType != AREA_TRANSITION_LINK_NONE) {
+		oTarget = GetObjectByTag(sTargetTag);
+		if (oTarget == OBJECT_INVALID)
+			return OBJECT_INVALID;
+		if (nLinkType == AREA_TRANSITION_LINK_DOOR && GetObjectType(oTarget) != OBJECT_TYPE_DOOR)
+			return OBJECT_INVALID;
+		if (nLinkType == AREA_TRANSITION_LINK_WAYPOINT && GetObjectType(oTarget) != OBJECT_TYPE_WAYPOINT)
+			return OBJECT_INVALID;
+	}
+
+	// create the trigger
     object oTrigger = CreateTrapAtLocation(1, lLocation, fSize, sTag);
-    if(GetIsObjectValid(oTrigger)) {
-        SetLocalString(oTrigger, "NWNX!FUNCSEXT!SETISAREATRANSITION", "          ");
-        DeleteLocalString(oTrigger, "NWNX!FUNCSEXT!SETISAREATRANSITION");
-        if(nLinkType != AREA_TRANSITION_LINK_NONE) {
-            object oTarget;
-            if(nLinkType == AREA_TRANSITION_LINK_DOOR) {
-                int nNth;
-                for(nNth=0;nNth<25;++nNth) {
-                    object oTmp = GetObjectByTag(sTargetTag, nNth);
-                    if(GetObjectType(oTmp) == OBJECT_TYPE_DOOR) {
-                        oTarget = oTmp;
-                        break;
-                    }
-                }
-            } else
-            if(nLinkType == AREA_TRANSITION_LINK_WAYPOINT) {
-                oTarget = GetWaypointByTag("sTargetTag");
-            }
-            if(GetIsObjectValid(oTarget)) {
-                SetLocalObject(oTrigger, "FUNCSEXT_TRANSITION_TARGET", oTarget);
-            }
-            SetScript(oTrigger, TRIGGER_SCRIPT_TRANSITION_CLICK, "funcsext_trgclk");
-        }
-    }
-    return oTrigger;
+	if (GetIsObjectValid(oTrigger)) {
+		SetLocalString(oTrigger, "NWNX!FUNCSEXT!SETISAREATRANSITION", "          ");
+		DeleteLocalString(oTrigger, "NWNX!FUNCSEXT!SETISAREATRANSITION");
+		if (nLinkType != AREA_TRANSITION_LINK_NONE) {
+			SetLocalObject(oTrigger, "FUNCSEXT_TRANSITION_TARGET", oTarget);
+			SetScript(oTrigger, NWNX_SCRIPT_TRIGGER_TRANSITION_CLICK, "funcsext_trgclk");
+		}
+	}
+	return oTrigger;
 }
 
 int GetSurface(location lLocation) {
@@ -208,11 +306,59 @@ int GetSurface(location lLocation) {
     return StringToInt(sRet);
 }
 
-int GetAnimation(object oTarget) {
+int GetAnimation(object oTarget)
+{
     SetLocalString(oTarget, "NWNX!FUNCSEXT!GETANIMATION", "                ");
     string sRet = GetLocalString(oTarget, "NWNX!FUNCSEXT!GETANIMATION");
     DeleteLocalString(oTarget, "NWNX!FUNCSEXT!GETANIMATION");
-    return StringToInt(sRet);
+
+	// map nwnx-returned animations to std nwn animations
+	switch(StringToInt(sRet)) {
+	  case NWNX_ANIMATION_LOOPING_PAUSE2:			return ANIMATION_LOOPING_PAUSE2;
+	  case NWNX_ANIMATION_LOOPING_LISTEN:			return ANIMATION_LOOPING_LISTEN;
+	  case NWNX_ANIMATION_LOOPING_MEDITATE:			return ANIMATION_LOOPING_MEDITATE;
+	  case NWNX_ANIMATION_LOOPING_WORSHIP:			return ANIMATION_LOOPING_WORSHIP;
+	  case NWNX_ANIMATION_LOOPING_LOOK_FAR:			return ANIMATION_LOOPING_LOOK_FAR;
+	  case NWNX_ANIMATION_LOOPING_SIT_CHAIR:		return ANIMATION_LOOPING_SIT_CHAIR;
+	  case NWNX_ANIMATION_LOOPING_SIT_CROSS:		return ANIMATION_LOOPING_SIT_CROSS;
+	  case NWNX_ANIMATION_LOOPING_TALK_NORMAL:		return ANIMATION_LOOPING_TALK_NORMAL;
+	  case NWNX_ANIMATION_LOOPING_TALK_PLEADING:	return ANIMATION_LOOPING_TALK_PLEADING;
+	  case NWNX_ANIMATION_LOOPING_TALK_FORCEFUL:	return ANIMATION_LOOPING_TALK_FORCEFUL;
+	  case NWNX_ANIMATION_LOOPING_TALK_LAUGHING:	return ANIMATION_LOOPING_TALK_LAUGHING;
+	  case NWNX_ANIMATION_LOOPING_GET_LOW:			return ANIMATION_LOOPING_GET_LOW;
+	  case NWNX_ANIMATION_LOOPING_GET_MID:			return ANIMATION_LOOPING_GET_MID;
+	  case NWNX_ANIMATION_LOOPING_PAUSE_TIRED:		return ANIMATION_LOOPING_PAUSE_TIRED;
+	  case NWNX_ANIMATION_LOOPING_PAUSE_DRUNK:		return ANIMATION_LOOPING_PAUSE_DRUNK;
+	  case NWNX_ANIMATION_LOOPING_DEAD_FRONT:		return ANIMATION_LOOPING_DEAD_FRONT;
+	  case NWNX_ANIMATION_LOOPING_DEAD_BACK:		return ANIMATION_LOOPING_DEAD_BACK;
+	  case NWNX_ANIMATION_LOOPING_CONJURE1:			return ANIMATION_LOOPING_CONJURE1;
+	  case NWNX_ANIMATION_LOOPING_CONJURE2:			return ANIMATION_LOOPING_CONJURE2;
+	  case NWNX_ANIMATION_LOOPING_SPASM:			return ANIMATION_LOOPING_SPASM;
+	  case NWNX_ANIMATION_LOOPING_CUSTOM1:			return ANIMATION_LOOPING_CUSTOM1;
+	  case NWNX_ANIMATION_LOOPING_CUSTOM2:			return ANIMATION_LOOPING_CUSTOM2;
+	  case NWNX_ANIMATION_LOOPING_CUSTOM3:			return ANIMATION_LOOPING_CUSTOM3;
+	  case NWNX_ANIMATION_LOOPING_CUSTOM4:			return ANIMATION_LOOPING_CUSTOM4;
+	  case NWNX_ANIMATION_LOOPING_CUSTOM5:			return ANIMATION_LOOPING_CUSTOM5;
+	  case NWNX_ANIMATION_LOOPING_CUSTOM6:			return ANIMATION_LOOPING_CUSTOM6;
+	  case NWNX_ANIMATION_LOOPING_CUSTOM7:			return ANIMATION_LOOPING_CUSTOM7;
+	  case NWNX_ANIMATION_LOOPING_CUSTOM8:			return ANIMATION_LOOPING_CUSTOM8;
+	  case NWNX_ANIMATION_LOOPING_CUSTOM9:			return ANIMATION_LOOPING_CUSTOM9;
+	  case NWNX_ANIMATION_LOOPING_CUSTOM10:			return ANIMATION_LOOPING_CUSTOM10;
+	  case NWNX_ANIMATION_LOOPING_CUSTOM11:			return ANIMATION_LOOPING_CUSTOM11;
+	  case NWNX_ANIMATION_LOOPING_CUSTOM12:			return ANIMATION_LOOPING_CUSTOM12;
+	  case NWNX_ANIMATION_LOOPING_CUSTOM13:			return ANIMATION_LOOPING_CUSTOM13;
+	  case NWNX_ANIMATION_LOOPING_CUSTOM14:			return ANIMATION_LOOPING_CUSTOM14;
+	  case NWNX_ANIMATION_LOOPING_CUSTOM15:			return ANIMATION_LOOPING_CUSTOM15;
+	  case NWNX_ANIMATION_LOOPING_CUSTOM16:			return ANIMATION_LOOPING_CUSTOM16;
+	  case NWNX_ANIMATION_LOOPING_CUSTOM17:			return ANIMATION_LOOPING_CUSTOM17;
+	  case NWNX_ANIMATION_LOOPING_CUSTOM18:			return ANIMATION_LOOPING_CUSTOM18;
+	  case NWNX_ANIMATION_LOOPING_CUSTOM19:			return ANIMATION_LOOPING_CUSTOM19;
+	  case NWNX_ANIMATION_LOOPING_CUSTOM20:			return ANIMATION_LOOPING_CUSTOM20;
+	  case NWNX_ANIMATION_MOUNT1:					return ANIMATION_MOUNT1;
+	  case NWNX_ANIMATION_DISMOUNT1:				return ANIMATION_DISMOUNT1;
+	}
+
+    return 0;
 }
 
 void StartTimingBar(object oCreature, int nSeconds, string sScript) {
@@ -255,6 +401,7 @@ void PossessCreature(object oPC, object oCreature) {
     SetLocalString(oPC, "NWNX!FUNCSEXT!POSSESS", ObjectToString(oCreature));
     DeleteLocalString(oPC, "NWNX!FUNCSEXT!POSSESS");
 }
+
 void UnPossessCreature(object oPC, object oCreature) {
     SetLocalString(oPC, "NWNX!FUNCSEXT!UNPOSSESS", "            ");
     DeleteLocalString(oPC, "NWNX!FUNCSEXT!UNPOSSESS");


### PR DESCRIPTION
changes summary:
funcsext_trgclk.nss
	check validity of all objects before trying to transition
nwnx_funcsext.nss
	bugfix - CreateTransitionAtLocation() invalid for waypoint and door transition types
	bugfix - GetAnimation() returns nonsensical values
	bugfix - names of some constants for SetScript() misspelled, resulting in syntax errors
	reorganized names of SCRIPT_* constants to find more easily in script editor
	corrected name of CreateTransitionOnLocation() to grammatically correct CreateTransitionAtLocation()