### PR TITLE
STR_RES: flesh out fields; needed for tlk->FetchInternal

### DIFF
--- a/api/nwnstructs.h
+++ b/api/nwnstructs.h
@@ -590,6 +590,9 @@ struct PEERJoinResult {
 struct MessageType {
 };
 struct STR_RES {
+    CExoString Text;
+    CResRef SoundResRef;
+    float SoundLength;
 };
 struct CTlkTableToken {
 };


### PR DESCRIPTION
Not sure if there's a better way to do this.

```C++
    STR_RES* tlkStr = new STR_RES;
    g_pTlkTable->FetchInternal(myref, *tlkStr, mygender);
    // Do stuff
    delete tlkStr;
```