### PR TITLE
gperf: fix generating lookup tables on c++11/newer gccs

### DIFF
--- a/plugins/gperf_gen.sh
+++ b/plugins/gperf_gen.sh
@@ -15,4 +15,8 @@ sed -i 's/^const struct/static const struct/' "gperf.out" || rm -f "gperf.out"
 
 sed -i 's/|| defined __GNUC_GNU_INLINE__//' "gperf.out" || rm -f "gperf.out"
 
+sed -i 's/defined __GNUC_STDC_INLINE__/0/' "gperf.out" || rm -f "gperf.out"
+
+sed -i 's/__attribute__ ((__gnu_inline__))//' "gperf.out" || rm -f "gperf.out"
+
 mv "gperf.out" "${V}Cmds.h"


### PR DESCRIPTION
This is just more aggressive in killing the inline hints gperf adds.