### PR TITLE
Added target_tick_rate.

### DIFF
--- a/plugins/optimizations/HookFunc.cpp
+++ b/plugins/optimizations/HookFunc.cpp
@@ -137,8 +137,8 @@ int HookFunctions()
     });
 
     // No-op the delay code.
-    constexpr static uintptr_t address = 0x0804BBF1;
-    constexpr static size_t length = 13;
+    constexpr static uintptr_t address = 0x0804BBEE;
+    constexpr static size_t length = 16;
     d_enable_write(address);
     memset(reinterpret_cast<void*>(address), 0x90, length);
 

--- a/plugins/optimizations/HookFunc.h
+++ b/plugins/optimizations/HookFunc.h
@@ -24,6 +24,6 @@
 #include "NWNStructures.h"
 
 int HookFunctions();
-void TestRequest();
+void SetTargetTickRate(const unsigned int rate);
 
 #endif

--- a/plugins/optimizations/NWNXOptimizations.cpp
+++ b/plugins/optimizations/NWNXOptimizations.cpp
@@ -58,11 +58,19 @@ bool CNWNXOptimizations::OnCreate(gline *config, const char* LogDir)
     if (!CNWNXBase::OnCreate(config, log))
         return false;
 
+    unsigned int targetTickRate = 30;
+
     if (nwnxConfig->exists(confKey))
     {
         std::string tickrate = (*nwnxConfig)[confKey]["target_tick_rate"];
-        SetTargetTickRate(tickrate.empty() ? 30 : std::atoi(tickrate.c_str()));
+
+        if (!tickrate.empty())
+        {
+            targetTickRate = std::atoi(tickrate.c_str());
+        }
     }
+
+    SetTargetTickRate(targetTickRate);
 
     // write copy information to the log file
     Log(0, "NWNX Optimizations version 1.0 for Linux.\n");

--- a/plugins/optimizations/NWNXOptimizations.cpp
+++ b/plugins/optimizations/NWNXOptimizations.cpp
@@ -58,6 +58,12 @@ bool CNWNXOptimizations::OnCreate(gline *config, const char* LogDir)
     if (!CNWNXBase::OnCreate(config, log))
         return false;
 
+    if (nwnxConfig->exists(confKey))
+    {
+        std::string tickrate = (*nwnxConfig)[confKey]["target_tick_rate"];
+        SetTargetTickRate(tickrate.empty() ? 30 : std::atoi(tickrate.c_str()));
+    }
+
     // write copy information to the log file
     Log(0, "NWNX Optimizations version 1.0 for Linux.\n");
     Log(0, "(c) 2010 by virusman (virusman@virusman.ru)\n");


### PR DESCRIPTION
This adds target_tick_rate, which defaults to 30 and allows users to specify via nwnx2.ini the desired amount of updates per second.

It also changes the logic to apply the sleep manually by nooping the original code and removing the average update time logic. This better enforces that we don't exceed the target tick rate and improved performance when update intervals are jittery (slow updates during a fast update period won't sleep now, where they used to before, exacerbating the sudden performance drop).