### PR TITLE
make -O2 default on Release builds and force -O0 for all current code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,10 +35,12 @@ set(CMAKE_SHARED_LIBRARY_CXX_FLAGS "")
 # nwnx is currently still kind of broken with -O > 0. Until that's properly fixed
 # and tested, force -O0 for release and relwithdebinfo builds. Individual
 # plugins can always override this!
-SET(CMAKE_C_FLAGS_RELEASE "-O0 -DNDEBUG")
-SET(CMAKE_CXX_FLAGS_RELEASE "-O0 -DNDEBUG")
-SET(CMAKE_C_FLAGS_RELWITHDEBINFO "-O0")
-SET(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O0")
+SET(CMAKE_C_FLAGS_DEBUG "-g -ggdb3 -gdwarf-4 -fno-eliminate-unused-debug-types")
+SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
+SET(CMAKE_C_FLAGS_RELEASE "-O2 -DNDEBUG")
+SET(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
+SET(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_DEBUG} -O2 -DNDEBUG")
+SET(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_DEBUG} -O2 -DNDEBUG")
 
 enable_language(ASM)
 
@@ -85,6 +87,9 @@ add_library(nwnx2 SHARED nwnx2lib NWNXBase modules lists gline
 
 # for core/ThreadUtil
 target_link_libraries(nwnx2 pthread)
+
+# The core library doesnt really work yet with -O2.
+set_target_properties(nwnx2 PROPERTIES COMPILE_FLAGS "-O0")
 
 # Fake target to force recreating the compiled directory.
 add_custom_target(always_rebuild_compiled ALL

--- a/plugins/areas/CMakeLists.txt
+++ b/plugins/areas/CMakeLists.txt
@@ -1,2 +1,4 @@
 add_module(areas CExoLinkedList CExoLocString HookFunc NWNXAreas
 	plugin-areas)
+
+set_target_properties(areas PROPERTIES COMPILE_FLAGS "-O0")

--- a/plugins/chat/CMakeLists.txt
+++ b/plugins/chat/CMakeLists.txt
@@ -3,9 +3,9 @@ include_directories(
     .
 )
 
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-return-type")
-
 add_module(chat
     HookChat
     NWNXChat
     plugin-chat)
+
+set_target_properties(chat PROPERTIES COMPILE_FLAGS "-O0")

--- a/plugins/connect/CMakeLists.txt
+++ b/plugins/connect/CMakeLists.txt
@@ -1,3 +1,5 @@
 include_directories(../../api)
 
 add_module(connect ConnectHooks NWNXConnect plugin-connect)
+
+set_target_properties(connect PROPERTIES COMPILE_FLAGS "-O0")

--- a/plugins/defenses/CMakeLists.txt
+++ b/plugins/defenses/CMakeLists.txt
@@ -63,4 +63,6 @@ add_module(defenses NWNXDefenses plugin-defenses
 	tables/t_DefenseSaveFeats
 )
 
+set_target_properties(defenses PROPERTIES COMPILE_FLAGS "-O0")
+
 endif (gperf)

--- a/plugins/dmactions/CMakeLists.txt
+++ b/plugins/dmactions/CMakeLists.txt
@@ -1,2 +1,4 @@
 add_module(dmactions FunctionHooks NWNXdmactions
 	plugin-dmactions)
+
+set_target_properties(dmactions PROPERTIES COMPILE_FLAGS "-O0")

--- a/plugins/events/CMakeLists.txt
+++ b/plugins/events/CMakeLists.txt
@@ -3,3 +3,5 @@ add_module(events
     NWNXEvents
     plugin-events
 )
+
+set_target_properties(events PROPERTIES COMPILE_FLAGS "-O0")

--- a/plugins/extend/CMakeLists.txt
+++ b/plugins/extend/CMakeLists.txt
@@ -1,1 +1,3 @@
 add_module(extend Hooks NWNXextend plugin-extend)
+
+set_target_properties(extend PROPERTIES COMPILE_FLAGS "-O0")

--- a/plugins/fixes/CMakeLists.txt
+++ b/plugins/fixes/CMakeLists.txt
@@ -1,3 +1,5 @@
 include_directories(../../api)
 
 add_module(fixes FixesHooks FixesHooksNewApi NWNXFixes plugin-fixes)
+
+set_target_properties(fixes PROPERTIES COMPILE_FLAGS "-O0")

--- a/plugins/funcs/CMakeLists.txt
+++ b/plugins/funcs/CMakeLists.txt
@@ -132,4 +132,6 @@ add_module(funcs NWNXFuncs plugin-funcs
 	funcs/vfx/f_BroadcastProjectile
 )
 
+set_target_properties(funcs PROPERTIES COMPILE_FLAGS "-O0")
+
 endif (gperf)

--- a/plugins/funcsext/CMakeLists.txt
+++ b/plugins/funcsext/CMakeLists.txt
@@ -1,1 +1,3 @@
 add_module(funcsext FunctionHooks NWNXFuncsExt plugin-funcsext)
+
+set_target_properties(funcsext PROPERTIES COMPILE_FLAGS "-O0")

--- a/plugins/hashset/CMakeLists.txt
+++ b/plugins/hashset/CMakeLists.txt
@@ -1,1 +1,3 @@
 add_module(hashset NWNXHashSet plugin-hashset)
+
+set_target_properties(hashset PROPERTIES COMPILE_FLAGS "-O0")

--- a/plugins/jvm/CMakeLists.txt
+++ b/plugins/jvm/CMakeLists.txt
@@ -25,6 +25,8 @@ if (JNI_FOUND AND JAVA_FOUND)
 		org_nwnx_nwnx2_jvm_NWScript_addon)
 	target_link_libraries(jvm ${JAVA_JVM_LIBRARY})
 
+    set_target_properties(jvm PROPERTIES COMPILE_FLAGS "-O0")
+
 	add_subdirectory(java)
 else (JNI_FOUND AND JAVA_FOUND)
 	message(WARNING "Cannot find java libraries")

--- a/plugins/lua/CMakeLists.txt
+++ b/plugins/lua/CMakeLists.txt
@@ -3,6 +3,9 @@ if (LUA51_FOUND)
 	include_directories(${LUA_INCLUDE_DIR})
 	add_module(lua FunctionHooks lua_int NWNXLua plugin-lua)
 	target_link_libraries(lua ${LUA_LIBRARIES})
+
+    set_target_properties(lua PROPERTIES COMPILE_FLAGS "-O0")
+
 else (LUA51_FOUND)
 	message(WARNING "Cannot find lua5.1 libraries")
 endif (LUA51_FOUND)

--- a/plugins/mhash/CMakeLists.txt
+++ b/plugins/mhash/CMakeLists.txt
@@ -10,5 +10,7 @@ add_module(mhash
 
 target_link_libraries(mhash ${MHASH_LIBRARY} ${UUID_LIBRARY})
 
+set_target_properties(mhash PROPERTIES COMPILE_FLAGS "-O0")
+
 endif (MHASH_LIBRARY)
 endif (UUID_LIBRARY)

--- a/plugins/mnx/CMakeLists.txt
+++ b/plugins/mnx/CMakeLists.txt
@@ -1,1 +1,3 @@
 add_module(mnx NWNXmnx plugin-mnx)
+
+set_target_properties(mnx PROPERTIES COMPILE_FLAGS "-O0")

--- a/plugins/names/CMakeLists.txt
+++ b/plugins/names/CMakeLists.txt
@@ -1,1 +1,3 @@
 add_module(names CCustomNames HookFunc NWNXNames plugin-names)
+
+set_target_properties(names PROPERTIES COMPILE_FLAGS "-O0")

--- a/plugins/odmbc/CMakeLists.txt
+++ b/plugins/odmbc/CMakeLists.txt
@@ -10,6 +10,8 @@ if (PostgreSQL_FOUND)
 	add_module(odmbc_pgsql pgsql ${all_deps})
 	target_link_libraries(odmbc_pgsql ${PostgreSQL_LIBRARIES})
 
+    set_target_properties(odmbc_pgsql PROPERTIES COMPILE_FLAGS "-O0")
+
 	set_target_properties(odmbc_pgsql
 		PROPERTIES COMPILE_FLAGS "-DPGSQL_SUPPORT=1")
 else (PostgreSQL_FOUND)
@@ -26,6 +28,8 @@ if (SQLITE3_FOUND)
 	add_module(odmbc_sqlite sqlite ${all_deps})
 	target_link_libraries(odmbc_sqlite ${SQLITE3_LIBRARIES})
 
+    set_target_properties(odmbc_sqlite PROPERTIES COMPILE_FLAGS "-O0")
+
 	set_target_properties(odmbc_sqlite
 		PROPERTIES COMPILE_FLAGS "-DSQLITE_SUPPORT=1")
 else (SQLITE3_FOUND)
@@ -41,6 +45,8 @@ if (MYSQL_FOUND)
 
 	add_module(odmbc_mysql mysql ${all_deps})
 	target_link_libraries(odmbc_mysql ${MYSQL_LIBRARY})
+
+    set_target_properties(odmbc_mysql PROPERTIES COMPILE_FLAGS "-O0")
 
 	#add_module(odmbc_mysql_static mysql ${all_deps})
 	#target_link_libraries(odmbc_mysql_static mysqlclient.a)

--- a/plugins/optimizations/CMakeLists.txt
+++ b/plugins/optimizations/CMakeLists.txt
@@ -1,1 +1,3 @@
 add_module(optimizations HookFunc NWNXOptimizations plugin-optimizations)
+
+set_target_properties(optimizations PROPERTIES COMPILE_FLAGS "-O0")

--- a/plugins/profiler/CMakeLists.txt
+++ b/plugins/profiler/CMakeLists.txt
@@ -1,1 +1,3 @@
 add_module(profiler hash HookRunScript NWNXProfiler plugin-profiler)
+
+set_target_properties(profiler PROPERTIES COMPILE_FLAGS "-O0")

--- a/plugins/reset/CMakeLists.txt
+++ b/plugins/reset/CMakeLists.txt
@@ -1,1 +1,3 @@
 add_module(reset NWNXReset plugin-reset)
+
+set_target_properties(reset PROPERTIES COMPILE_FLAGS "-O0")

--- a/plugins/resman/CMakeLists.txt
+++ b/plugins/resman/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_module(resman HookDemandRes NWNXResMan plugin-resman DirectoryHandler)
 
-set_target_properties(resman PROPERTIES COMPILE_FLAGS "-Wno-return-type")
+set_target_properties(resman PROPERTIES COMPILE_FLAGS "-O0")

--- a/plugins/ruby/CMakeLists.txt
+++ b/plugins/ruby/CMakeLists.txt
@@ -4,6 +4,9 @@ if (RUBY_FOUND)
 	include_directories(${RUBY_INCLUDE_DIRS})
 	add_module(ruby FunctionHooks ruby_int NWNXRuby plugin-ruby)
 	target_link_libraries(ruby ${RUBY_LIBRARY})
+
+    set_target_properties(ruby PROPERTIES COMPILE_FLAGS "-O0")
+
 else (RUBY_FOUND)
 	message(WARNING "Cannot find ruby libraries.")
 endif (RUBY_FOUND)

--- a/plugins/serverlist/CMakeLists.txt
+++ b/plugins/serverlist/CMakeLists.txt
@@ -1,1 +1,3 @@
 add_module(serverlist ServerlistHooks NWNXServerlist plugin-serverlist)
+
+set_target_properties(serverlist PROPERTIES COMPILE_FLAGS "-O0")

--- a/plugins/spells/CMakeLists.txt
+++ b/plugins/spells/CMakeLists.txt
@@ -26,4 +26,6 @@ add_module(spells NWNXSpells plugin-spells
 	tables/t_SpellOptions
 )
 
+set_target_properties(spells PROPERTIES COMPILE_FLAGS "-O0")
+
 endif (gperf)

--- a/plugins/structs/CMakeLists.txt
+++ b/plugins/structs/CMakeLists.txt
@@ -22,4 +22,6 @@ add_module(structs NWNXStructs plugin-structs
 	hooks/h_PushStruct
 )
 
+set_target_properties(structs PROPERTIES COMPILE_FLAGS "-O0")
+
 endif (gperf)

--- a/plugins/system/CMakeLists.txt
+++ b/plugins/system/CMakeLists.txt
@@ -24,4 +24,6 @@ add_module(system NWNXSystem plugin-system
 	funcs/f_TrueRandom
 )
 
+set_target_properties(system PROPERTIES COMPILE_FLAGS "-O0")
+
 endif (gperf)

--- a/plugins/tmi/CMakeLists.txt
+++ b/plugins/tmi/CMakeLists.txt
@@ -1,1 +1,3 @@
 add_module(tmi NWNXTMI plugin-tmi)
+
+set_target_properties(tmi PROPERTIES COMPILE_FLAGS "-O0")

--- a/plugins/tweaks/CMakeLists.txt
+++ b/plugins/tweaks/CMakeLists.txt
@@ -14,4 +14,6 @@ add_module(tweaks NWNXTweaks plugin-tweaks
 	tables/t_TweakOptions
 )
 
+set_target_properties(tweaks PROPERTIES COMPILE_FLAGS "-O0")
+
 endif (gperf)

--- a/plugins/vaultster/CMakeLists.txt
+++ b/plugins/vaultster/CMakeLists.txt
@@ -7,6 +7,9 @@ if (Boost_FOUND)
 	add_module(vaultster NWNXVaultster client blowfish plugin-vaultster)
 	target_link_libraries(vaultster z ${Boost_LIBRARIES})
 
+    set_target_properties(vaultster-server PROPERTIES COMPILE_FLAGS "-O0")
+    set_target_properties(vaultster PROPERTIES COMPILE_FLAGS "-O0")
+
 else (Boost_FOUND)
 	message(WARNING "Cannot find boost libraries, not building vaultster")
 endif (Boost_FOUND)

--- a/plugins/visibility/CMakeLists.txt
+++ b/plugins/visibility/CMakeLists.txt
@@ -1,2 +1,4 @@
 add_module(visibility CExoLinkedList HookFunc NWNXVisibility
 	plugin-visibility)
+
+set_target_properties(visibility PROPERTIES COMPILE_FLAGS "-O0")

--- a/plugins/weapons/CMakeLists.txt
+++ b/plugins/weapons/CMakeLists.txt
@@ -96,4 +96,6 @@ add_module(weapons NWNXWeapons plugin-weapons
 	tables/t_WeaponSuperiorCritical
 )
 
+set_target_properties(weapons PROPERTIES COMPILE_FLAGS "-O0")
+
 endif (gperf)


### PR DESCRIPTION
This commit makes -O2 the default on release and relwithdebinfo builds,
then forces -O0 on nwnx2 and all in-tree plugin cmakelists.

My proposed way forward is:
* new plugins are -O2 by default
* test and fix/rewrite piece by piece code to work on -O2 as
  time/effort/motivation/gain warrants

This also adds -DNDEBUG which was missing from the last patch, and adds
some awesome gdb-related debug flags to DEBUG builds so you get full
symbols in gdb.

--

please discuss!