### PR TITLE
plugins/odmbc/pgsql: fix compile errors due to missing spaces in literal-concatenated string

### DIFF
--- a/plugins/odmbc/pgsql.cpp
+++ b/plugins/odmbc/pgsql.cpp
@@ -60,7 +60,7 @@ BOOL CPgSQL::Connect(const char *server, const char *user, const char *pass, con
                                       + strlen(user)
                                       + strlen(pass));
     // Build the connection string
-    sprintf(connstring, HOST"%s "PORT"%hu "DB"%s "USR"%s "PW"%s", server, PORT_NUM, db, user, pass);
+    sprintf(connstring, HOST "%s " PORT "%hu " DB "%s " USR "%s " PW "%s", server, PORT_NUM, db, user, pass);
 
     // Connect attempt
     pgsql = PQconnectdb(connstring);


### PR DESCRIPTION
So, yeah. Unbreak pgsql compilation on gcc 4.7.x. I know, boring.