### PR TITLE
Specify global scope on call to socket bind

### DIFF
--- a/plugins/mnx/NWNXmnx.cpp
+++ b/plugins/mnx/NWNXmnx.cpp
@@ -104,7 +104,7 @@ bool CNWNXmnx::ClientInit(const char *cname, const char *dest)
     cliAddr.sin_addr.s_addr = htonl(INADDR_ANY);
     cliAddr.sin_port = htons(0);
 
-    rc = bind(conn.sd, (struct sockaddr *) &cliAddr, sizeof(cliAddr));
+    rc = ::bind(conn.sd, (struct sockaddr *) &cliAddr, sizeof(cliAddr));
     if (rc < 0) {
         Log(0, "[%s] cannot bind port\n", cname);
         close(conn.sd);


### PR DESCRIPTION
On Ubuntu 12.04 mnx was refusing to build after picking up std::bind
a C++11 feature to bind keywords rather than the global socket call.

I'm unable to test this, but expect no issues with pinning down the scope.
