### PR TITLE
Increased logging detail on logged messages to include a date-time stamp

### DIFF
--- a/NWNXBase.cpp
+++ b/NWNXBase.cpp
@@ -69,10 +69,18 @@ unsigned long CNWNXBase::OnRequestObject(char *gameObject, char* Request)
 
 void CNWNXBase::Log(int priority, const char *pcMsg, ...)
 {
-    va_list argList;
-    char acBuffer[2048];
+    va_list    argList;
+    char       acBuffer[2048];
+    time_t     now = time(0);
+    struct tm  tstruct;
 
     if (m_fFile && priority <= debuglevel) {
+        // build timestamp
+
+        tstruct = *localtime(&now);
+        strftime(acBuffer, sizeof(acBuffer), "[%Y-%m-%d %X] ", &tstruct);
+        fputs(acBuffer, m_fFile);
+
         // build up the string
         va_start(argList, pcMsg);
         vsnprintf(acBuffer, 2047, pcMsg, argList);


### PR DESCRIPTION
having multiple log files with non-timestamped entries makes correlating events between files difficult.

this change adds a simple [yyyy-mm-dd HH:MM:SS] timestamp at the beginning of each line logged to the various nwnx2 logfiles.