### PR TITLE
added several new functions to nwnx_areas. added new hexdump utility.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ SET(OUR_CFLAGS_MUST_HAVES "${OUR_CFLAGS_MUST_HAVES} -m32")
 
 # - no-omit-frame-pointer: breaks assembly on -O1/-O2 for some plugins
 # - no-accumulate-outgoing-args: same
-SET(OUR_CFLAGS_MUST_HAVES "${OUR_CFLAGS_MUST_HAVES} -mno-accumulate-outgoing-args -fno-omit-frame-pointer -fno-pic")
+SET(OUR_CFLAGS_MUST_HAVES "${OUR_CFLAGS_MUST_HAVES} -mno-accumulate-outgoing-args -fno-omit-frame-pointer")
 # - warnings: self-explanatory
 SET(OUR_CFLAGS_MUST_HAVES "${OUR_CFLAGS_MUST_HAVES} -Wall -Wextra -Wno-unused-parameter -Wno-unused -Wno-write-strings")
 
@@ -37,7 +37,6 @@ set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} ${OUR_CFLAGS_MUST_HAVES}" CACHE STRING "
 # removes stuff like -fPIC, which breaks nwnx plugin loading
 set(CMAKE_SHARED_LIBRARY_C_FLAGS "")
 set(CMAKE_SHARED_LIBRARY_CXX_FLAGS "")
-set(CMAKE_POSITION_INDEPENDENT_CODE FALSE)
 
 # nwnx is currently still kind of broken with -O > 0. Until that's properly fixed
 # and tested, force -O0 for release and relwithdebinfo builds. Individual
@@ -81,6 +80,7 @@ add_library(nwnx2 SHARED nwnx2lib NWNXBase modules lists gline
 	lib/nwn_data lib/nwn_funcs lib/nwn_hooks
 	lib/nx_hook lib/nx_log lib/nx_safe lib/nx_signature
 	lib/NwnDefines
+	lib/hexdump
 	api/nwnsyms.S api/all
 
     core/core

--- a/include/hexdump.h
+++ b/include/hexdump.h
@@ -1,0 +1,35 @@
+/*
+ *  NWNeXalt - hexdump.h
+ *  - advance declarations and macro definitions to support the 'hexdump'
+ *  routine.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ *  $Id$
+ *  $HeadURL$
+ *
+ */
+
+#define	HDBUFSIZE	2048
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+char *hexdump(void *datap, int osize);
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/hexdump.c
+++ b/lib/hexdump.c
@@ -1,0 +1,84 @@
+/*
+ *  NWNeXalt - hexdump.c
+ *  - dump an area of memory to the log file, as ascii formatted text.
+ *
+ *  parameters -
+ *	void*	the location of memory to dump
+ *	int		the number of bytes to dump
+ *
+ *	returns -
+ *	char*	a formatted string that can be used to send to the log file
+ *			on error [the required dump length would overflow the buffer],
+ *			an error string is returned
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ *  $Id$
+ *  $HeadURL$
+ *
+ */
+
+#include <sys/types.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include "hexdump.h"
+
+
+char *hexdump(void *datap, int osize)
+{
+	static	char	outbuf[BUFSIZ];
+			char	bytebuf[8], asciibuf[22];
+			int		i, width;
+			u_char *dump = (unsigned char *)datap;
+
+	if (osize >= BUFSIZ / 5) {	// every byte dumped takes 5 to display
+		sprintf(outbuf, "hexdump: the required memory area (%d) exceeds the buffer space available (%d)",
+			osize, BUFSIZ / 5);
+		return outbuf;
+	}
+
+	outbuf[0] = 0;
+	i = 0;
+	while (i < osize) {
+		if (i % 16 == 0) {
+			if (i > 0)
+				strcat(outbuf, asciibuf);
+			sprintf(bytebuf, "0x%04x:  ", i);
+			strcat(outbuf, bytebuf);
+			strcpy(asciibuf, "|................|\n");
+		}
+		sprintf(bytebuf, "%02x ", *dump);
+		strcat(outbuf, bytebuf);
+		if (i % 8 == 7)
+			strcat(outbuf, " ");
+		if (*dump >= ' ' && *dump < 127)
+			asciibuf[(i % 16) + 1] = *dump;
+		++i, ++dump;
+	}
+
+	// extend unused area to align asciibuf
+	while (i % 16) {
+		if (i % 8 == 7)
+			strcat(outbuf, " ");
+		strcat(outbuf, "   ");
+		asciibuf[(i % 16) + 1] = ' ';
+		++i;
+	}
+
+	strcat(outbuf, asciibuf);
+
+	return outbuf;
+}

--- a/plugins/areas/CMakeLists.txt
+++ b/plugins/areas/CMakeLists.txt
@@ -1,9 +1,20 @@
 add_module(areas
-    NWNXAreas plugin-areas
+	NWNXAreas plugin-areas
 
-    Services
+	Services
 
-    funcs/LoadArea
-    funcs/UnloadArea
-    funcs/UpdateCreatures
+	funcs/DumpArea
+	funcs/GetAreaHeight
+	funcs/GetAreaLighting
+	funcs/GetAreaListen
+	funcs/GetAreaSpot
+	funcs/GetAreaTileset
+	funcs/GetAreaWidth
+	funcs/GetNoRest
+	funcs/LoadArea
+	funcs/SetAreaListen
+	funcs/SetAreaName
+	funcs/SetAreaSpot
+	funcs/UnloadArea
+	funcs/UpdateCreatures
 )

--- a/plugins/areas/NWNXAreas.cpp
+++ b/plugins/areas/NWNXAreas.cpp
@@ -27,7 +27,7 @@ nwobjid lastAreaId = OBJECT_INVALID;
 
 char* CNWNXAreas::OnRequest(char* gameObject, char* Request, char* Parameters)
 {
-    Log(2, "Request: %s\n", Request);
+    Log(2, "Request: %s(%s)\n", Request, Parameters);
 
     if (strncmp(Request, "CREATE_AREA", 11) == 0) {
         auto area = LoadArea(Parameters);
@@ -35,15 +35,35 @@ char* CNWNXAreas::OnRequest(char* gameObject, char* Request, char* Parameters)
             lastAreaId = area->ObjectID;
         else
             lastAreaId = OBJECT_INVALID;
-
         return NULL;
-
     } else if (strncmp(Request, "DESTROY_AREA", 12) == 0) {
         bool ret = UnloadArea(strtol(Parameters, NULL, 16));
         char* sret;
         asprintf(&sret, "%d", ret);
         return sret;
-    }
+    } else if (strncmp(Request, "DUMP_AREA", 9) == 0) {
+        NWNXDumpArea(gameObject, strtol(Parameters, (char **)NULL, 16));
+    } else if (strncmp(Request, "GET_AREA_TILESET", 16) == 0) {
+        strncpy(Parameters, NWNXGetAreaTileset(gameObject, strtol(Parameters, (char **)NULL, 16)), strlen(Parameters));
+    } else if (strncmp(Request, "GET_AREA_NO_REST", 16) == 0) {
+        snprintf(Parameters, strlen(Parameters), "%d", NWNXGetNoRest(gameObject, strtol(Parameters, (char **)NULL, 16)));
+    } else if (strncmp(Request, "GET_AREA_HEIGHT", 15) == 0) {
+        snprintf(Parameters, strlen(Parameters), "%d", NWNXGetAreaHeight(gameObject, strtol(Parameters, (char **)NULL, 16)));
+    } else if (strncmp(Request, "GET_AREA_WIDTH", 14) == 0) {
+        snprintf(Parameters, strlen(Parameters), "%d", NWNXGetAreaWidth(gameObject, strtol(Parameters, (char **)NULL, 16)));
+    } else if (strncmp(Request, "GET_AREA_LIGHTING", 17) == 0) {
+        snprintf(Parameters, strlen(Parameters), "%d", NWNXGetAreaLighting(gameObject, strtol(Parameters, (char **)NULL, 16)));
+    } else if (strncmp(Request, "GET_AREA_LISTEN_MOD", 19) == 0) {
+        snprintf(Parameters, strlen(Parameters), "%d", NWNXGetAreaListen(gameObject, strtol(Parameters, (char **)NULL, 16)));
+    } else if (strncmp(Request, "GET_AREA_SPOT_MOD", 17) == 0) {
+        snprintf(Parameters, strlen(Parameters), "%d", NWNXGetAreaSpot(gameObject, strtol(Parameters, (char **)NULL, 16)));
+    } else if (strncmp(Request, "SET_AREA_LISTEN_MOD", 19) == 0) {
+        NWNXSetAreaListen((CNWSArea *)(gameObject - 0xC4), Parameters);
+    } else if (strncmp(Request, "SET_AREA_SPOT_MOD", 17) == 0) {
+        NWNXSetAreaSpot((CNWSArea *)(gameObject - 0xC4), Parameters);
+    } else if (strncmp(Request, "SET_AREA_NAME", 13) == 0) {
+        NWNXSetAreaName((CNWSArea *)(gameObject - 0xC4), Parameters);
+	}
 
     return NULL;
 }

--- a/plugins/areas/NWNXAreas.h
+++ b/plugins/areas/NWNXAreas.h
@@ -8,15 +8,12 @@
 #include <memory.h>
 #include <stddef.h>
 #include <unistd.h>
-
 #include <string>
 #include <future>
 #include <cassert>
-
 #include "gline.h"
-
 #include "pluginlink.h"
-
+#include "area_info.h"
 #include "funcs/Funcs.h"
 
 class CNWNXAreas : public CNWNXBase

--- a/plugins/areas/area_info.h
+++ b/plugins/areas/area_info.h
@@ -1,0 +1,157 @@
+/***************************************************************************
+	area_info.h
+	this structure details the information contained in the nwn in-memory
+	area structure. it differs from CNWSArea in that this structure is
+	complete, whereas CNWSArea contains data starting only from offset 0xd4.
+
+	------------------------------------------------------------------------
+    Areas plugin for NWNX
+    (c) 2010 virusman (virusman@virusman.ru)
+    modifications 2018 by niv, xorbaxian
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ ***************************************************************************/
+
+#ifndef _AREA_INFO_H_
+# define _AREA_INFO_H_
+
+struct area_info {
+    /* 0x000/0 */	unsigned long object_id;
+    /* 0x004/4 */	unsigned long width;
+    /* 0x008/8 */	unsigned long height;
+    /* 0x00C/12 */	unsigned long field_0C;
+    /* 0x010/16 */	unsigned long field_10;
+    /* 0x014/20 */	unsigned long field_14;
+    /* 0x018/24 */	unsigned long field_18;
+    /* 0x01C/28 */	unsigned long field_1C;
+    /* 0x020/32 */	unsigned long field_20;
+    /* 0x024/36 */	unsigned long field_24;
+    /* 0x028/40 */	unsigned long field_28;
+    /* 0x02C/44 */	unsigned long field_2C;
+    /* 0x030/48 */	unsigned long field_30;
+    /* 0x034/52 */	unsigned long field_34;
+    /* 0x038/56 */	unsigned long field_38;
+    /* 0x03C/60 */	unsigned long field_3C;
+    /* 0x040/   */	unsigned long field_40;
+    /* 0x044/   */	unsigned long field_44;
+    /* 0x048/   */	unsigned long field_48;
+    /* 0x04C/   */	unsigned long field_4C;
+    /* 0x050/   */	unsigned long field_50;
+    /* 0x054/   */	unsigned long field_54;
+    /* 0x058/   */	unsigned long field_58;
+    /* 0x05C/   */	unsigned long field_5C;
+    /* 0x060/   */	unsigned long field_60;
+    /* 0x064/   */	unsigned long field_64;
+    /* 0x068/   */	unsigned long field_68;
+    /* 0x06C/   */	unsigned long field_6C;
+    /* 0x070/   */	unsigned long field_70;
+    /* 0x074/   */	unsigned long field_74;
+    /* 0x078/   */	unsigned long field_78;
+    /* 0x07C/   */	unsigned long field_7C;
+    /* 0x080/128 */	unsigned long field_80;
+    /* 0x084/132 */	unsigned long field_84;
+    /* 0x088/136 */	unsigned long field_88;
+    /* 0x08C/140 */	unsigned long field_8C;
+    /* 0x090/144 */	unsigned long field_90;
+    /* 0x094/148 */	unsigned long field_94;
+    /* 0x098/152 */	unsigned long no_rest;
+    /* 0x09C/156 */	unsigned long field_9C;
+    /* 0x0A0/160 */	unsigned long field_A0;
+    /* 0x0A4/164 */	unsigned long area;
+    /* 0x0A8/168 */	unsigned long field_A8;
+    /* 0x0AC/172 */	unsigned long field_AC;
+    /* 0x0B0/176 */	char resref[16];
+    /* 0x0C0/192 */	unsigned long CResARE;
+    /* 0x0C4/196 */	CGameObject GameObject;
+    /* 0x0D4/212 */	unsigned long NumPlayers;
+    /* 0x0D8/216 */	CExoArrayList<nwobjid> TrapList;
+    /* 0x0E4/228 */	unsigned long ObjectByNameIndex;
+    /* 0x0E8/232 */	unsigned long m_nLastHeartbeatScriptCalendarDay;
+    /* 0x0EC/236 */	unsigned long m_nLastHeartbeatScriptTimeOfDay;
+    /* 0x0F0/240 */	unsigned long field_F0;
+    /* 0x0F4/244 */	unsigned long field_F4;
+    /* 0x0F8/248 */	unsigned long field_F8;
+    /* 0x0FC/252 */	CExoLocString Name;
+    /* 0x104/260 */ CExoString Tag;
+    /* 0x10C/268 */ char tileset[16];
+    /* 0x11C/284 */	unsigned long field_11C;
+    /* 0x120/288 */ CNWSTile *Tiles;
+    /* 0x124/292 */ unsigned long field_124;
+    /* 0x128/296 */ CExoString m_sHeartbeatScript;
+    /* 0x130/304 */ unsigned long field_130;
+    /* 0x134/308 */ unsigned long field_134;
+    /* 0x138/    */	unsigned long field_138;
+    /* 0x13C/    */	unsigned long field_13C;
+    /* 0x140/    */	unsigned long field_140;
+    /* 0x144/    */	unsigned long field_144;
+    /* 0x148/    */	unsigned long field_148;
+    /* 0x14C/332 */	int mod_spot;
+    /* 0x150/336 */	int mod_listen;
+    /* (mtype:CExoArrayList<unsigned long>) */
+    /* 0x154/340 */ CExoArrayList<unsigned long> ObjectList;
+    /* 0x160/352 */ unsigned long CurrentObjectIndex;
+    /* 0x164/356 */ CExoArrayList<unsigned long> SubAreas;
+    /* 0x170/368 */ unsigned long field_170;
+    /* 0x174/372 */ unsigned long field_174;
+    /* 0x178/376 */ unsigned long field_178;
+    /* 0x17C/380 */ unsigned long field_17C;
+    /* 0x180/384 */ unsigned long field_180;
+    /* 0x184/388 */ unsigned long field_184;
+    /* 0x188/392 */ unsigned long field_188;
+    /* 0x18C/396 */ unsigned long field_18C;
+    /* 0x190/400 */ unsigned long field_190;
+    /* 0x194/404 */ unsigned long field_194;
+    /* 0x198/408 */ CPathfindInformation* PathfindInformation;
+    /* 0x19C/412 */ unsigned long SoundPathInformation;
+    /* 0x1A0/416 */ unsigned long field_1A0;
+    /* 0x1A4/420 */ unsigned long field_1A4;
+    /* 0x1A8/424 */ unsigned long field_1A8;
+    /* 0x1AC/428 */ unsigned long field_1AC;
+    /* 0x1B0/432 */ unsigned long field_1B0;
+    /* 0x1B4/436 */ unsigned long field_1B4;
+    /* 0x1B8/440 */ unsigned long field_1B8;
+    /* 0x1BC/444 */ unsigned long field_1BC;
+    /* 0x1C0/448 */ nwobjid LastEntered;
+    /* 0x1C4/452 */ nwobjid LastExited;
+    /* 0x1C8/456 */ unsigned long CustomScriptEventId;
+    /* 0x1CC/460 */ unsigned long field_1CC;
+    /* 0x1D0/464 */ unsigned long field_1D0;
+    /* 0x1D4/468 */ unsigned long InterAreaDFSVisited;
+    /* 0x1D8/472 */ CNWSScriptVarTable VarTable;
+    /* 0x1E0/480 */ unsigned long field_1E0;
+    /* 0x1E4/484 */ unsigned long field_1E4;
+    /* 0x1E8/488 */ unsigned long AmbientSound;
+    /* 0x1EC/492 */	unsigned long field_1EC;
+    /* 0x1F0/496 */ char WeatherStarted;
+    /* 0x1F1/497 */ char rsvd5[3];
+    /* 0x1F4/500 */	unsigned long field_1F4;
+    /* 0x1F8/504 */ unsigned long m_nLastUpdateCalendarDay;
+    /* 0x1FC/508 */ unsigned long m_nLastUpdateTimeOfDay;
+    /* 0x200/512 */ unsigned char OverrideWeather;
+    /* 0x201/513 */ unsigned char CurrentWeather;
+    /* 0x202/514 */	unsigned char lighting;
+    /* 0x203/515 */ unsigned char PVPSetting;
+    /* 0x204/516 */ unsigned long tilecount;
+    /* 0x208/520 */ unsigned long field_208;
+    /* 0x20C/524 */ unsigned long LoadScreenID;
+};
+
+typedef struct area_info area_info_s;
+
+static_assert_size(area_info_s, 0x210);
+
+#endif
+
+/* vim: set ts=4 sw=4: */

--- a/plugins/areas/funcs/DumpArea.cpp
+++ b/plugins/areas/funcs/DumpArea.cpp
@@ -1,0 +1,53 @@
+/***************************************************************************
+    Areas plugin for NWNX
+    (c) 2010 virusman (virusman@virusman.ru)
+    modifications 2018 by niv, xorbaxian
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ ***************************************************************************/
+
+#include "../NWNXAreas.h"
+#include "hexdump.h"
+
+void dump_area(struct area_info *ap)
+{
+	areas.Log(0, "dump_area: area width=%d, area height=%d, no-rest = %d\n", ap->width, ap->height, ap->no_rest);
+	areas.Log(0, "dump_area: resref = %s, tileset = %s, spot = %d, listen = %d, lighting = %d\n",
+		ap->resref, ap->tileset, ap->mod_spot, ap->mod_listen, ap->lighting);
+	areas.Log(0, "dump_area: dumping %d bytes from %p...\n", sizeof(CNWSArea), ap);
+
+	// for some strange, bizarre, and wholly inexplicable reason,
+	// the nwnx logger's output buffer is limited to 2k.
+	// output the dump line by line. *sigh*
+	char *dump = hexdump((void *)ap, sizeof(CNWSArea));
+	char *tok = strtok(dump, "\n");
+	while (tok) {
+		areas.Log(0, "%s\n", tok);
+		tok = strtok(NULL, "\n");
+	}
+	areas.Log(0, "dump_area: DUMP ENDS ----------------\n");
+}
+
+void NWNXDumpArea(void *pModule, dword areaId)
+{
+	if (areaId <= 0 || areaId == OBJECT_INVALID) {
+		areas.Log(1, "Invalid area ID passed to NWNXDumpArea\n");//debug
+		return;
+	}
+	areas.Log(0, "Dumping area %08lX\n", areaId);
+	dump_area((struct area_info *)g_pAppManager->ServerExoApp->GetAreaByGameObjectID(areaId));
+}
+
+/* vim: set ts=4 sw=4: */

--- a/plugins/areas/funcs/Funcs.h
+++ b/plugins/areas/funcs/Funcs.h
@@ -1,3 +1,28 @@
+/***************************************************************************
+    Funcs.h -
+    advance declarations and definitions for use in functions of nwnx_areas
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ ***************************************************************************/
+
+typedef unsigned long dword;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Loads an area, returns nullptr on failure.
 CNWSArea* LoadArea(const std::string& resref);
 
@@ -6,6 +31,32 @@ bool UnloadArea(nwobjid areaId);
 
 // Update all player minimap lists. Used internally.
 void UpdateCreatures();
+
+// global function / alt entry point, if actual area is available
+void dump_area(CNWSArea *ap);
+
+void NWNXDumpArea(void *pModule, dword nAreaID);
+
+int NWNXGetAreaHeight(void *pModule, dword nAreaID);
+
+int NWNXGetAreaWidth(void *pModule, dword nAreaID);
+
+int NWNXGetAreaLighting(void *pModule, dword nAreaID);
+
+int NWNXGetAreaListen(void *pModule, dword nAreaID);
+
+int NWNXGetAreaSpot(void *pModule, dword nAreaID);
+
+int NWNXGetNoRest(void *pModule, dword nAreaID);
+
+char* NWNXGetAreaTileset(void *pModule, dword nAreaID);
+
+void NWNXSetAreaName(CNWSArea *pArea, char *sNewName);
+
+void NWNXSetAreaListen(CNWSArea *pArea, char *val);
+
+void NWNXSetAreaSpot(CNWSArea *pArea, char *val);
+
 
 // Re-send area lists to all DMs. Used internally.
 inline void UpdateDMs()
@@ -25,3 +76,7 @@ inline void UpdateDMs()
 
     }
 }
+
+#ifdef __cplusplus
+}
+#endif

--- a/plugins/areas/funcs/GetAreaHeight.cpp
+++ b/plugins/areas/funcs/GetAreaHeight.cpp
@@ -1,7 +1,7 @@
-
 /***************************************************************************
-    NWNXFuncs.cpp - Implementation of the CNWNXFuncs class.
-    Copyright (C) 2007 Doug Swarin (zac@intertex.net)
+    Areas plugin for NWNX
+    (c) 2010 virusman (virusman@virusman.ru)
+    modifications 2018 by niv, xorbaxian
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -18,34 +18,16 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  ***************************************************************************/
 
-#include "NWNXFuncs.h"
+#include "../NWNXAreas.h"
 
-
-static unsigned int Area_Current = 0;
-static CNWSModule *Area_Module = NULL;
-
-
-nwn_objid_t Func_GetFirstArea(CGameObject *ob)
+int NWNXGetAreaHeight(void *pModule, dword areaId)
 {
-    if (Area_Module == NULL) {
-        Area_Module = CServerExoAppInternal__GetModule((*NWN_AppManager)->app_server->srv_internal);
-
-        if (Area_Module == NULL)
-            return OBJECT_INVALID;
-    }
-
-    Area_Current = 0;
-    return Func_GetNextArea(ob);
+	if (areaId <= 0 || areaId == OBJECT_INVALID) {
+		areas.Log(1, "Invalid area ID passed to NWNXGetAreaHeight\n");//debug
+		return 0;
+	}
+	area_info_s *ap = (area_info_s *)g_pAppManager->ServerExoApp->GetAreaByGameObjectID(areaId);
+	return ap->height;
 }
 
-
-nwn_objid_t Func_GetNextArea(CGameObject *ob)
-{
-    if (Area_Current >= Area_Module->mod_areas_len)
-        return OBJECT_INVALID;
-
-    return Area_Module->mod_areas[Area_Current++];
-}
-
-
-/* vim: set sw=4: */
+/* vim: set ts=4 sw=4: */

--- a/plugins/areas/funcs/GetAreaLighting.cpp
+++ b/plugins/areas/funcs/GetAreaLighting.cpp
@@ -1,7 +1,7 @@
-
 /***************************************************************************
-    NWNXFuncs.cpp - Implementation of the CNWNXFuncs class.
-    Copyright (C) 2007 Doug Swarin (zac@intertex.net)
+    Areas plugin for NWNX
+    (c) 2010 virusman (virusman@virusman.ru)
+    modifications 2018 by niv, xorbaxian
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -18,34 +18,16 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  ***************************************************************************/
 
-#include "NWNXFuncs.h"
+#include "../NWNXAreas.h"
 
-
-static unsigned int Area_Current = 0;
-static CNWSModule *Area_Module = NULL;
-
-
-nwn_objid_t Func_GetFirstArea(CGameObject *ob)
+int NWNXGetAreaLighting(void *pModule, dword areaId)
 {
-    if (Area_Module == NULL) {
-        Area_Module = CServerExoAppInternal__GetModule((*NWN_AppManager)->app_server->srv_internal);
-
-        if (Area_Module == NULL)
-            return OBJECT_INVALID;
-    }
-
-    Area_Current = 0;
-    return Func_GetNextArea(ob);
+	if (areaId <= 0 || areaId == OBJECT_INVALID) {
+		areas.Log(1, "Invalid area ID passed to NWNXGetAreaLighting\n");//debug
+		return -1;
+	}
+	area_info_s *ap = (area_info_s *)g_pAppManager->ServerExoApp->GetAreaByGameObjectID(areaId);
+	return ap->lighting;
 }
 
-
-nwn_objid_t Func_GetNextArea(CGameObject *ob)
-{
-    if (Area_Current >= Area_Module->mod_areas_len)
-        return OBJECT_INVALID;
-
-    return Area_Module->mod_areas[Area_Current++];
-}
-
-
-/* vim: set sw=4: */
+/* vim: set ts=4 sw=4: */

--- a/plugins/areas/funcs/GetAreaListen.cpp
+++ b/plugins/areas/funcs/GetAreaListen.cpp
@@ -1,7 +1,7 @@
-
 /***************************************************************************
-    NWNXFuncs.cpp - Implementation of the CNWNXFuncs class.
-    Copyright (C) 2007 Doug Swarin (zac@intertex.net)
+    Areas plugin for NWNX
+    (c) 2010 virusman (virusman@virusman.ru)
+    modifications 2018 by niv, xorbaxian
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -18,34 +18,16 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  ***************************************************************************/
 
-#include "NWNXFuncs.h"
+#include "../NWNXAreas.h"
 
-
-static unsigned int Area_Current = 0;
-static CNWSModule *Area_Module = NULL;
-
-
-nwn_objid_t Func_GetFirstArea(CGameObject *ob)
+int NWNXGetAreaListen(void *pModule, dword areaId)
 {
-    if (Area_Module == NULL) {
-        Area_Module = CServerExoAppInternal__GetModule((*NWN_AppManager)->app_server->srv_internal);
-
-        if (Area_Module == NULL)
-            return OBJECT_INVALID;
-    }
-
-    Area_Current = 0;
-    return Func_GetNextArea(ob);
+	if (areaId <= 0 || areaId == OBJECT_INVALID) {
+		areas.Log(1, "Invalid area ID passed to NWNXGetAreaListen\n");//debug
+		return 0;	// punt
+	}
+	area_info_s *ap = (area_info_s *)g_pAppManager->ServerExoApp->GetAreaByGameObjectID(areaId);
+	return ap->mod_listen;
 }
 
-
-nwn_objid_t Func_GetNextArea(CGameObject *ob)
-{
-    if (Area_Current >= Area_Module->mod_areas_len)
-        return OBJECT_INVALID;
-
-    return Area_Module->mod_areas[Area_Current++];
-}
-
-
-/* vim: set sw=4: */
+/* vim: set ts=4 sw=4: */

--- a/plugins/areas/funcs/GetAreaSpot.cpp
+++ b/plugins/areas/funcs/GetAreaSpot.cpp
@@ -1,7 +1,7 @@
-
 /***************************************************************************
-    NWNXFuncs.cpp - Implementation of the CNWNXFuncs class.
-    Copyright (C) 2007 Doug Swarin (zac@intertex.net)
+    Areas plugin for NWNX
+    (c) 2010 virusman (virusman@virusman.ru)
+    modifications 2018 by niv, xorbaxian
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -18,34 +18,16 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  ***************************************************************************/
 
-#include "NWNXFuncs.h"
+#include "../NWNXAreas.h"
 
-
-static unsigned int Area_Current = 0;
-static CNWSModule *Area_Module = NULL;
-
-
-nwn_objid_t Func_GetFirstArea(CGameObject *ob)
+int NWNXGetAreaSpot(void *pModule, dword areaId)
 {
-    if (Area_Module == NULL) {
-        Area_Module = CServerExoAppInternal__GetModule((*NWN_AppManager)->app_server->srv_internal);
-
-        if (Area_Module == NULL)
-            return OBJECT_INVALID;
-    }
-
-    Area_Current = 0;
-    return Func_GetNextArea(ob);
+	if (areaId <= 0 || areaId == OBJECT_INVALID) {
+		areas.Log(1, "Invalid area ID passed to NWNXGetAreaSpot\n");//debug
+		return 0;	// punt
+	}
+	area_info_s *ap = (area_info_s *)g_pAppManager->ServerExoApp->GetAreaByGameObjectID(areaId);
+	return ap->mod_spot;
 }
 
-
-nwn_objid_t Func_GetNextArea(CGameObject *ob)
-{
-    if (Area_Current >= Area_Module->mod_areas_len)
-        return OBJECT_INVALID;
-
-    return Area_Module->mod_areas[Area_Current++];
-}
-
-
-/* vim: set sw=4: */
+/* vim: set ts=4 sw=4: */

--- a/plugins/areas/funcs/GetAreaTileset.cpp
+++ b/plugins/areas/funcs/GetAreaTileset.cpp
@@ -1,7 +1,7 @@
-
 /***************************************************************************
-    NWNXFuncs.cpp - Implementation of the CNWNXFuncs class.
-    Copyright (C) 2007 Doug Swarin (zac@intertex.net)
+    Areas plugin for NWNX
+    (c) 2010 virusman (virusman@virusman.ru)
+    modifications 2018 by niv, xorbaxian
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -18,34 +18,16 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  ***************************************************************************/
 
-#include "NWNXFuncs.h"
+#include "../NWNXAreas.h"
 
-
-static unsigned int Area_Current = 0;
-static CNWSModule *Area_Module = NULL;
-
-
-nwn_objid_t Func_GetFirstArea(CGameObject *ob)
+char *NWNXGetAreaTileset(void *pModule, dword areaId)
 {
-    if (Area_Module == NULL) {
-        Area_Module = CServerExoAppInternal__GetModule((*NWN_AppManager)->app_server->srv_internal);
-
-        if (Area_Module == NULL)
-            return OBJECT_INVALID;
-    }
-
-    Area_Current = 0;
-    return Func_GetNextArea(ob);
+	if (areaId <= 0 || areaId == OBJECT_INVALID) {
+		areas.Log(1, "Invalid area ID passed to NWNXGetAreaTileset\n");//debug
+		return (char *)0;
+	}
+	area_info_s *ap = (area_info_s *)g_pAppManager->ServerExoApp->GetAreaByGameObjectID(areaId);
+	return ap->tileset;
 }
 
-
-nwn_objid_t Func_GetNextArea(CGameObject *ob)
-{
-    if (Area_Current >= Area_Module->mod_areas_len)
-        return OBJECT_INVALID;
-
-    return Area_Module->mod_areas[Area_Current++];
-}
-
-
-/* vim: set sw=4: */
+/* vim: set ts=4 sw=4: */

--- a/plugins/areas/funcs/GetAreaWidth.cpp
+++ b/plugins/areas/funcs/GetAreaWidth.cpp
@@ -1,7 +1,7 @@
-
 /***************************************************************************
-    NWNXFuncs.cpp - Implementation of the CNWNXFuncs class.
-    Copyright (C) 2007 Doug Swarin (zac@intertex.net)
+    Areas plugin for NWNX
+    (c) 2010 virusman (virusman@virusman.ru)
+    modifications 2018 by niv, xorbaxian
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -18,34 +18,16 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  ***************************************************************************/
 
-#include "NWNXFuncs.h"
+#include "../NWNXAreas.h"
 
-
-static unsigned int Area_Current = 0;
-static CNWSModule *Area_Module = NULL;
-
-
-nwn_objid_t Func_GetFirstArea(CGameObject *ob)
+int NWNXGetAreaWidth(void *pModule, dword areaId)
 {
-    if (Area_Module == NULL) {
-        Area_Module = CServerExoAppInternal__GetModule((*NWN_AppManager)->app_server->srv_internal);
-
-        if (Area_Module == NULL)
-            return OBJECT_INVALID;
-    }
-
-    Area_Current = 0;
-    return Func_GetNextArea(ob);
+	if (areaId <= 0 || areaId == OBJECT_INVALID) {
+		areas.Log(1, "Invalid area ID passed to NWNXGetAreaWidth\n");//debug
+		return 0;
+	}
+	area_info_s *ap = (area_info_s *)g_pAppManager->ServerExoApp->GetAreaByGameObjectID(areaId);
+	return ap->width;
 }
 
-
-nwn_objid_t Func_GetNextArea(CGameObject *ob)
-{
-    if (Area_Current >= Area_Module->mod_areas_len)
-        return OBJECT_INVALID;
-
-    return Area_Module->mod_areas[Area_Current++];
-}
-
-
-/* vim: set sw=4: */
+/* vim: set ts=4 sw=4: */

--- a/plugins/areas/funcs/GetNoRest.cpp
+++ b/plugins/areas/funcs/GetNoRest.cpp
@@ -1,7 +1,7 @@
-
 /***************************************************************************
-    NWNXFuncs.cpp - Implementation of the CNWNXFuncs class.
-    Copyright (C) 2007 Doug Swarin (zac@intertex.net)
+    Areas plugin for NWNX
+    (c) 2010 virusman (virusman@virusman.ru)
+    modifications 2018 by niv, xorbaxian
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -18,34 +18,16 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  ***************************************************************************/
 
-#include "NWNXFuncs.h"
+#include "../NWNXAreas.h"
 
-
-static unsigned int Area_Current = 0;
-static CNWSModule *Area_Module = NULL;
-
-
-nwn_objid_t Func_GetFirstArea(CGameObject *ob)
+int NWNXGetNoRest(void *pModule, dword areaId)
 {
-    if (Area_Module == NULL) {
-        Area_Module = CServerExoAppInternal__GetModule((*NWN_AppManager)->app_server->srv_internal);
-
-        if (Area_Module == NULL)
-            return OBJECT_INVALID;
-    }
-
-    Area_Current = 0;
-    return Func_GetNextArea(ob);
+	if (areaId <= 0 || areaId == OBJECT_INVALID) {
+		areas.Log(1, "Invalid area ID passed to NWNXGetNoRest\n");//debug
+		return -1;
+	}
+	area_info_s *ap = (area_info_s *)g_pAppManager->ServerExoApp->GetAreaByGameObjectID(areaId);
+	return ap->no_rest;
 }
 
-
-nwn_objid_t Func_GetNextArea(CGameObject *ob)
-{
-    if (Area_Current >= Area_Module->mod_areas_len)
-        return OBJECT_INVALID;
-
-    return Area_Module->mod_areas[Area_Current++];
-}
-
-
-/* vim: set sw=4: */
+/* vim: set ts=4 sw=4: */

--- a/plugins/areas/funcs/SetAreaListen.cpp
+++ b/plugins/areas/funcs/SetAreaListen.cpp
@@ -1,7 +1,7 @@
-
 /***************************************************************************
-    NWNXFuncs.cpp - Implementation of the CNWNXFuncs class.
-    Copyright (C) 2007 Doug Swarin (zac@intertex.net)
+    Areas plugin for NWNX
+    (c) 2010 virusman (virusman@virusman.ru)
+    modifications 2018 by niv, xorbaxian
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -18,34 +18,14 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  ***************************************************************************/
 
-#include "NWNXFuncs.h"
+#include "../NWNXAreas.h"
 
-
-static unsigned int Area_Current = 0;
-static CNWSModule *Area_Module = NULL;
-
-
-nwn_objid_t Func_GetFirstArea(CGameObject *ob)
+void NWNXSetAreaListen(CNWSArea *pArea, char *val)
 {
-    if (Area_Module == NULL) {
-        Area_Module = CServerExoAppInternal__GetModule((*NWN_AppManager)->app_server->srv_internal);
-
-        if (Area_Module == NULL)
-            return OBJECT_INVALID;
-    }
-
-    Area_Current = 0;
-    return Func_GetNextArea(ob);
+	area_info *ap = (area_info *)pArea;
+	ap->mod_listen = atoi(val);
+    UpdateCreatures();
+    UpdateDMs();
 }
 
-
-nwn_objid_t Func_GetNextArea(CGameObject *ob)
-{
-    if (Area_Current >= Area_Module->mod_areas_len)
-        return OBJECT_INVALID;
-
-    return Area_Module->mod_areas[Area_Current++];
-}
-
-
-/* vim: set sw=4: */
+/* vim: set ts=4 sw=4: */

--- a/plugins/areas/funcs/SetAreaName.cpp
+++ b/plugins/areas/funcs/SetAreaName.cpp
@@ -1,7 +1,7 @@
-
 /***************************************************************************
-    NWNXFuncs.cpp - Implementation of the CNWNXFuncs class.
-    Copyright (C) 2007 Doug Swarin (zac@intertex.net)
+    Areas plugin for NWNX
+    (c) 2010 virusman (virusman@virusman.ru)
+    modifications 2018 by niv, xorbaxian
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -18,34 +18,28 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  ***************************************************************************/
 
-#include "NWNXFuncs.h"
+#include "../NWNXAreas.h"
 
-
-static unsigned int Area_Current = 0;
-static CNWSModule *Area_Module = NULL;
-
-
-nwn_objid_t Func_GetFirstArea(CGameObject *ob)
+void NWNXSetAreaName(CNWSArea *pArea, char *sNewName)
 {
-    if (Area_Module == NULL) {
-        Area_Module = CServerExoAppInternal__GetModule((*NWN_AppManager)->app_server->srv_internal);
+	areas.Log(0, "*** SetAreaName is non-functional ***\n");
 
-        if (Area_Module == NULL)
-            return OBJECT_INVALID;
-    }
+/* broken since nwnx_areas rewrite
 
-    Area_Current = 0;
-    return Func_GetNextArea(ob);
+	areas.Log(3, "SetAreaName: %x, '%s'\n", pArea->GameObject.ObjectID, sNewName);
+
+	lsName->AddString(0, (CExoString *)0, newstr);
+	CExoLocString *lsName = (CExoLocString *)&pArea->Name;
+	if (!lsName)
+		return;
+	int len = strlen(sNewName);
+	char *newstr = new char[len + 1];
+	strncpy(newstr, sNewName, len);
+	newstr[len] = 0;
+
+    UpdateCreatures();
+    UpdateDMs();
+*/
 }
 
-
-nwn_objid_t Func_GetNextArea(CGameObject *ob)
-{
-    if (Area_Current >= Area_Module->mod_areas_len)
-        return OBJECT_INVALID;
-
-    return Area_Module->mod_areas[Area_Current++];
-}
-
-
-/* vim: set sw=4: */
+/* vim: set ts=4 sw=4: */

--- a/plugins/areas/funcs/SetAreaSpot.cpp
+++ b/plugins/areas/funcs/SetAreaSpot.cpp
@@ -1,7 +1,7 @@
-
 /***************************************************************************
-    NWNXFuncs.cpp - Implementation of the CNWNXFuncs class.
-    Copyright (C) 2007 Doug Swarin (zac@intertex.net)
+    Areas plugin for NWNX
+    (c) 2010 virusman (virusman@virusman.ru)
+    modifications 2018 by niv, xorbaxian
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -18,34 +18,14 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  ***************************************************************************/
 
-#include "NWNXFuncs.h"
+#include "../NWNXAreas.h"
 
-
-static unsigned int Area_Current = 0;
-static CNWSModule *Area_Module = NULL;
-
-
-nwn_objid_t Func_GetFirstArea(CGameObject *ob)
+void NWNXSetAreaSpot(CNWSArea *pArea, char *val)
 {
-    if (Area_Module == NULL) {
-        Area_Module = CServerExoAppInternal__GetModule((*NWN_AppManager)->app_server->srv_internal);
-
-        if (Area_Module == NULL)
-            return OBJECT_INVALID;
-    }
-
-    Area_Current = 0;
-    return Func_GetNextArea(ob);
+	area_info *ap = (area_info *)pArea;
+	ap->mod_spot = atoi(val);
+    UpdateCreatures();
+    UpdateDMs();
 }
 
-
-nwn_objid_t Func_GetNextArea(CGameObject *ob)
-{
-    if (Area_Current >= Area_Module->mod_areas_len)
-        return OBJECT_INVALID;
-
-    return Area_Module->mod_areas[Area_Current++];
-}
-
-
-/* vim: set sw=4: */
+/* vim: set ts=4 sw=4: */

--- a/plugins/areas/nwnx_areas.nss
+++ b/plugins/areas/nwnx_areas.nss
@@ -1,18 +1,154 @@
-// Create new area from ResRef.
-// Will return OBJECT_INVALID on failure.
+// NWNX Areas
+// Area instancing and data manipulation plugin
+// (c) by virusman, 2006-2010
+// additions (c) 2018 by niv, xorbaxian
+
+// Create new area from ResRef
 object CreateArea(string sResRef);
 
-// Destroy area. Will return FALSE on failure.
-int DestroyArea(object oArea);
+// Destroy area oArea
+void DestroyArea(object oArea);
+
+// Create new area from ResRef. Same as CreateArea
+// this function is DEPRECATED, included only for backward compatibility
+object LoadArea(string sResRef);
+
+// given a valid area oArea, dump the structure's contents to the server log.
+// this should be used for debugging only.
+void DumpArea(object oArea);
+
+// Set name for oArea
+void SetAreaName(object oArea, string sName);
+
+// given a valid area oArea, return the name of the tileset the area was built with
+string GetAreaTileset(object oArea);
+
+// given a valid area oArea, return how many tiles across it is (i.e., East-West)
+// returns 0 on error
+int GetAreaWidth(object oArea);
+
+// given a valid area oArea, return how many tiles it is long (i.e., North-South)
+// returns 0 on error
+int GetAreaHeight(object oArea);
+
+// given a valid area oArea, return the id that determines its lighting effects,
+//   as given in environment.2da
+// returns -1 on error
+int GetAreaLighting(object oArea);
+
+// given a valid area oArea, return TRUE if the area has the 'no rest' flag
+//   set, otherwise return FALSE
+// returns FALSE on error
+int GetNoRest(object oArea);
+
+// given a valid area oArea, return the area's global listen skill modifier
+// returns 0 on error
+int GetAreaListenMod(object oArea);
+
+// given a valid area oArea, return the area's global spot skill modifier
+// returns 0 on error
+int GetAreaSpotMod(object oArea);
+
+// given a valid area oArea and an integer argument 'mod' from -127 to 127,
+// set the area's global listen skill modifier to the provided argument
+void SetAreaListenMod(object oArea, int mod);
+
+// given a valid area oArea and an integer argument 'mod' from -127 to 127,
+// set the area's global listen skill modifier to the provided argument
+void SetAreaSpotMod(object oArea, int mod);
+
 
 object CreateArea(string sResRef)
 {
-    SetLocalString(GetModule(), "NWNX!AREAS!CREATE_AREA", sResRef);
-    return GetLocalObject(GetModule(), "NWNX!AREAS!GET_LAST_AREA_ID");
+    object oM = GetModule();
+    SetLocalString(oM, "NWNX!AREAS!CREATE_AREA", sResRef);
+    return GetLocalObject(oM, "NWNX!AREAS!GET_LAST_AREA_ID");
 }
 
 void DestroyArea(object oArea)
 {
-    SetLocalString(GetModule(), "NWNX!AREAS!DESTROY_AREA", ObjectToString(oArea));
-    return StringToInt(GetLocalString(GetModule(), "NWNX!AREAS!DESTROY_AREA"));
+    object oM = GetModule();
+    SetLocalString(oM, "NWNX!AREAS!DESTROY_AREA", ObjectToString(oArea));
+}
+
+object LoadArea(string sResRef)
+{
+    return CreateArea(sResRef);
+}
+
+void DumpArea(object oArea)
+{
+    object oM = GetModule();
+    SetLocalString(oM, "NWNX!AREAS!DUMP_AREA", ObjectToString(oArea));
+}
+
+string GetAreaTileset(object oArea)
+{
+	string padding = "                ";	// assure we have space for return value
+    object oM = GetModule();
+    SetLocalString(oM, "NWNX!AREAS!GET_AREA_TILESET", padding + ObjectToString(oArea));
+    return GetLocalString(oM, "NWNX!AREAS!GET_AREA_TILESET");
+}
+
+int GetAreaHeight(object oArea)
+{
+	string padding = "                ";	// assure we have space for return value
+    object oM = GetModule();
+    SetLocalString(oM, "NWNX!AREAS!GET_AREA_HEIGHT", padding + ObjectToString(oArea));
+    return StringToInt(GetLocalString(oM, "NWNX!AREAS!GET_AREA_HEIGHT"));
+}
+
+int GetAreaWidth(object oArea)
+{
+	string padding = "                ";	// assure we have space for return value
+    object oM = GetModule();
+    SetLocalString(oM, "NWNX!AREAS!GET_AREA_WIDTH", padding + ObjectToString(oArea));
+    return StringToInt(GetLocalString(oM, "NWNX!AREAS!GET_AREA_WIDTH"));
+}
+
+int GetNoRest(object oArea)
+{
+	string padding = "                ";	// assure we have space for return value
+    object oM = GetModule();
+    SetLocalString(oM, "NWNX!AREAS!GET_AREA_NO_REST", padding + ObjectToString(oArea));
+    return StringToInt(GetLocalString(oM, "NWNX!AREAS!GET_AREA_NO_REST"));
+}
+
+int GetAreaLighting(object oArea)
+{
+	string padding = "                ";	// assure we have space for return value
+    object oM = GetModule();
+    SetLocalString(oM, "NWNX!AREAS!GET_AREA_LIGHTING", padding + ObjectToString(oArea));
+    return StringToInt(GetLocalString(oM, "NWNX!AREAS!GET_AREA_LIGHTING"));
+}
+
+int GetAreaListenMod(object oArea)
+{
+	string padding = "                ";	// assure we have space for return value
+    object oM = GetModule();
+    SetLocalString(oM, "NWNX!AREAS!GET_AREA_LISTEN_MOD", padding + ObjectToString(oArea));
+    return StringToInt(GetLocalString(oM, "NWNX!AREAS!GET_AREA_LISTEN_MOD"));
+}
+
+int GetAreaSpotMod(object oArea)
+{
+	string padding = "                ";	// assure we have space for return value
+    object oM = GetModule();
+    SetLocalString(oM, "NWNX!AREAS!GET_AREA_SPOT_MOD", padding + ObjectToString(oArea));
+    return StringToInt(GetLocalString(oM, "NWNX!AREAS!GET_AREA_SPOT_MOD"));
+}
+
+void SetAreaListenMod(object oArea, int mod)
+{
+    SetLocalString(oArea, "NWNX!AREAS!SET_AREA_LISTEN_MOD", IntToString(mod));
+}
+
+void SetAreaSpotMod(object oArea, int mod)
+{
+    SetLocalString(oArea, "NWNX!AREAS!SET_AREA_SPOT_MOD", IntToString(mod));
+}
+
+void SetAreaName(object oArea, string sName)
+{
+    SetLocalString(oArea, "NWNX!AREAS!SET_AREA_NAME", sName);
 }

--- a/plugins/funcs/funcs/other/f_DumpObject.c
+++ b/plugins/funcs/funcs/other/f_DumpObject.c
@@ -1,4 +1,3 @@
-
 /***************************************************************************
     NWNXFuncs.cpp - Implementation of the CNWNXFuncs class.
     Copyright (C) 2007 Doug Swarin (zac@intertex.net)
@@ -19,57 +18,52 @@
  ***************************************************************************/
 
 #include "NWNXFuncs.h"
-
-char *stpcpy(char *dst, const char *src);
+#include "hexdump.h"
 
 
 void Func_DumpObject(CGameObject *ob, char *value)
 {
-    int i, j;
-    char buf[2048], chbuf[16], prbuf[32], *p;
-    unsigned char *dump = (unsigned char *)ob;
+    char buf[HDBUFSIZE];
+    int osize = HDBUFSIZE;	// object size. dump this much (round to line len)
 
-    sprintf(buf, "object: %p  tag: %s  type: %d", ob, ob->tag, ob->type);
-    p = buf + strlen(buf);
+	switch(ob->type) {
+	  case OBJECT_TYPE_AREA:
+		// global CNWSArea struct doesn't have tag or resref, as nwnx_areas does
+		osize = sizeof(CNWSArea);
+		sprintf(buf, "DUMP: AREA (object type %d): %p, %d bytes",
+			ob->type, ob, osize);
+		break;
+	  case OBJECT_TYPE_CREATURE:
+		osize = sizeof(CNWSCreature);
+		sprintf(buf, "DUMP: CREATURE (object type %d): tag: %s  resref: %s  id: %u (%#x)  stats: %p - %p, %d bytes",
+			ob->type, ob->tag, ob->resref, ob->id, ob->id, ((CNWSCreature *)ob)->cre_stats, ob, osize);
+		break;
+	  case OBJECT_TYPE_ITEM:
+		osize = sizeof(CNWSItem);
+		sprintf(buf, "DUMP: ITEM (object type %d): tag: %s  resref: %s  id: %u (%#x) - %p, %d bytes",
+			ob->type, ob->tag, ob->resref, ob->id, ob->id, ob, osize);
+		break;
+	  case OBJECT_TYPE_MODULE:
+		osize = sizeof(CNWSModule);
+		sprintf(buf, "DUMP: MODULE (object type %d): tag: %s  resref: %s  id: %u (%#x) - %p, %d bytes",
+			ob->type, ob->tag, ob->resref, ob->id, ob->id, ob, osize);
+		break;
+	  case OBJECT_TYPE_PLACEABLE:
+		osize = sizeof(CNWSPlaceable);
+		sprintf(buf, "DUMP: PLACEABLE (object type %d): tag: %s  resref: %s  id: %u (%#x) - %p, %d bytes",
+			ob->type, ob->tag, ob->resref, ob->id, ob->id, ob, osize);
+		break;
+	  case OBJECT_TYPE_WAYPOINT:
+		osize = sizeof(CNWSWaypoint);
+		sprintf(buf, "DUMP: WAYPOINT (object type %d): tag: %s  resref: %s  id: %u (%#x) - %p, %d bytes",
+			ob->type, ob->tag, ob->resref, ob->id, ob->id, ob, osize);
+		break;
+	  default:
+		sprintf(buf, "unrecognized object (type %d)  tag: %s  resref: %s  id: %u (%#x) - %p, %d bytes",
+			ob->type, ob->tag, ob->resref, ob->id, ob->id, ob, osize);
+	}
 
-    if (ob->type == 5) {
-        sprintf(p, "  creature: %p", ((CNWSCreature *)ob)->cre_stats);
-        p = buf + strlen(buf);
-    }
-
-    p = stpcpy(p, "\n");
-
-    for (i = 0; i < 16; i++) {
-        prbuf[0] = 0;
-
-        for (j = (i * 256); j < ((i + 1) * 256); j++) {
-            if (j % 16 == 0) {
-                snprintf(chbuf, sizeof(chbuf), "\n0x%04X:  ", j);
-                strcat(prbuf, chbuf);
-                p = stpcpy(p, prbuf);
-
-                snprintf(prbuf, sizeof(prbuf), "|................|");
-            }
-
-            if (j % 8 == 7)
-                snprintf(chbuf, sizeof(chbuf), "%02x  ", dump[j]);
-            else
-                snprintf(chbuf, sizeof(chbuf), "%02x ", dump[j]);
-
-            p = stpcpy(p, chbuf);
-
-            if (dump[j] >= ' ' && dump[j] < 127)
-                prbuf[(j % 16) + 1] = dump[j];
-        }
-
-        p = stpcpy(p, prbuf);
-        p = stpcpy(p, "\n");
-
-        nx_log(NX_LOG_DEBUG, 0, "%s", buf);
-
-        p = buf;
-    }
+	nx_log(NX_LOG_DEBUG, 0, buf);
+	nx_log(NX_LOG_DEBUG, 0, "\n%s", hexdump((void *)ob, osize));
+	nx_log(NX_LOG_DEBUG, 0, "DUMP ENDS ----------------\n");
 }
-
-
-/* vim: set sw=4: */


### PR DESCRIPTION
this pull request SUPERSEDES pull request #127. it is functionally identical to #127, but solves the dev conflicts that arose due to my taking so long on this. there should now be no conflicts w/dev work done by other contributors. please DISREGARD pull request #127 and use this one in its place.

sorry about the mix-up !

=== details ===
- plugins/areas/nwnx_areas.nss - added GetAreaTileset, GetAreaHeight, GetAreaWidth, GetAreaLighting, GetNoRest, Set/GetAreaListenMod, Set/GetAreaSpotMod, DumpArea
- plugins/areas/NWNXAreas.cpp - integrated above functions
- plugins/areas/area_info.h - support structure for area info output routines
- plugins/areas/NWNXAreas.h - include area_info.h
- plugins/areas/funcs/GetAreaHeight.cpp - implementation of above-named function
- plugins/areas/funcs/GetAreaLighting.cpp - implementation of above-named function
- plugins/areas/funcs/GetAreaListen.cpp - implementation of above-named function
- plugins/areas/funcs/GetAreaSpot.cpp - implementation of above-named function
- plugins/areas/funcs/GetAreaTileset.cpp - implementation of above-named function
- plugins/areas/funcs/GetAreaWidth.cpp - implementation of above-named function
- plugins/areas/funcs/GetNoRest.cpp - implementation of above-named function
- plugins/areas/funcs/SetAreaListen.cpp - implementation of above-named function
- plugins/areas/funcs/SetAreaName.cpp - implementation of above-named function
- plugins/areas/funcs/SetAreaSpot.cpp - implementation of above-named function
- plugins/areas/funcs/DumpArea.cpp - dump an area structure to log file
- plugins/areas/funcs/Funcs.h - advance declarations for above functions
- plugins/areas/CMakeLists.txt - added above files
- plugins/funcs/funcs/area/f_GetFirstNextArea.c - fastidious variable declaration to avoid compile-time warnings
- plugins/funcs/funcs/other/f_DumpObject.c - updated to output more intelligent header and use new hexdump utility
- CMakeLists.txt - added hexdump to lib
- lib/hexdump.c - new hexdump utility
- include/hexdump.h - required for linkage to new hexdump utility