### PR TITLE
Events: Devastating Critical hook and bypass

### DIFF
--- a/plugins/events/HookFunc.cpp
+++ b/plugins/events/HookFunc.cpp
@@ -669,7 +669,7 @@ int CNWSObject__dtor(uintptr_t p)
 int CNWSCreatureStats__GetEpicWeaponDevastatingCritical_hook(CNWSCreatureStats *pStats, CNWSItem *pItem)
 {
     int (*original)(CNWSCreatureStats*, CNWSItem*);
-    *(dword*)&original = (dword)&d_ret_code_vc;
+    *(dword*)&original = (dword)&d_ret_code_dc;
 
     if (original(pStats, pItem))
     {

--- a/plugins/events/HookFunc.cpp
+++ b/plugins/events/HookFunc.cpp
@@ -677,6 +677,13 @@ int CNWSCreatureStats__GetEpicWeaponDevastatingCritical_hook(CNWSCreatureStats *
         events.oItem = pItem->ObjectID;
         events.oTarget = pCreature->AttackTarget;
         events.FireEvent(pCreature->ObjectID, EVENT_TYPE_DEVASTATING_CRITICAL);
+        if (events.nReturnValue == 1)
+        {
+            // Set killing blow so cleave activates
+            CNWSCombatRound *pCombatRound = pCreature->CombatRound;
+            CNWSCombatAttackData *pAttackData = pCombatRound->GetAttack(pCombatRound->CurrentAttack);
+            pAttackData->KillingBlow = 1;
+        }
     }
 
     // Always return 0 so the core game doesn't do devcrit handling

--- a/plugins/events/NWNXEvents.h
+++ b/plugins/events/NWNXEvents.h
@@ -41,7 +41,8 @@
 #define EVENT_TYPE_VALIDATE_CHARACTER   13
 #define EVENT_TYPE_DESTROY_OBJECT       14
 #define EVENT_TYPE_CREATE_OBJECT        15
-#define NUM_EVENT_TYPES                 16
+#define EVENT_TYPE_DEVASTATING_CRITICAL 16
+#define NUM_EVENT_TYPES                 17
 
 enum eNodeType {StartingNode, EntryNode, ReplyNode};
 

--- a/plugins/events/nwn/nwnx_events.nss
+++ b/plugins/events/nwn/nwnx_events.nss
@@ -14,6 +14,7 @@ const int EVENT_TYPE_POSSESS_FAMILIAR   = 12;
 const int EVENT_TYPE_VALIDATE_CHARACTER = 13;
 const int EVENT_TYPE_DESTROY_OBJECT     = 14;
 const int EVENT_TYPE_CREATE_OBJECT      = 15;
+const int EVENT_TYPE_DEVASTATING_CRITICAL = 16;
 
 // DEPRECATED
 // For backwards compatibility only - use above constants instead

--- a/plugins/events/readme.txt
+++ b/plugins/events/readme.txt
@@ -50,6 +50,14 @@ Provides hooks for the following events:
                            <any number> - StrRef (TLK string) of the error message (the character won't be able to enter)
 * DestroyObject (unsafe)
     - OBJECT_SELF        = The object being destroyed
+* DevastatingCritical (can be blocked from script)
+    - OBJECT_SELF        = The attacker that is using DevCrit feat
+    - GetEventTarget()   = Creature being hit with the devastating critical
+    - GetEventSubType()  = Total damage being dealt to target
+    - GetEventItem()     = Attacker's weapon, in which the attacker has the devcrit feat
+    * BypassEvent()      = Override default devastating critical handling
+    * SetReturnValue()   = Whether the attacker gets a cleave attack. Only valid if BypassEvent() was called.
+
 
 Provides functions for conditional and action scripts:
     int GetCurrentNodeType();


### PR DESCRIPTION
Hooks the devcrit feat use, allowing blocking from script. The event is only fired if:

1. Attacker is scoring a critical on the target
2. The normal critical hit damage is not enough to kill the target
3. Attacker has devastating critical feat in the weapon scoring the critical

From script, use:
```
    - OBJECT_SELF        = The attacker that is using DevCrit feat
    - GetEventTarget()   = Creature being hit with the devastating critical
    - GetEventSubType()  = Total damage being dealt to target
    - GetEventItem()     = Attacker's weapon, in which the attacker has the devcrit feat
    * BypassEvent()      = Override default devastating critical handling
    * SetReturnValue()   = Whether the attacker gets a cleave attack. Only valid if BypassEvent() was called.
```

I updated the readme with the script parts, but didn't increment the version.